### PR TITLE
Fix PR workflow and compiler flags

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Update package list for i386
       run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
     - name: Install packages
-      run: sudo apt-get -y install build-essential g++-multilib gcc-mingw-w64
+      run: sudo apt-get -y install build-essential g++-multilib gcc-mingw-w64 g++-mingw-w64
     - name: make
       run: make
     - name: cleanup 1

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -15,5 +15,9 @@ jobs:
       run: sudo apt-get -y install build-essential g++-multilib gcc-mingw-w64
     - name: make
       run: make
+    - name: cleanup 1
+      run: git clean -xdf
     - name: make win32
       run: make OSTYPE=win32
+    - name: cleanup 2
+      run: git clean -xdf

--- a/Makefile
+++ b/Makefile
@@ -23,15 +23,13 @@ endif
 
 TARGET = jk_botti_mm
 BASEFLAGS = -Wall -Wno-write-strings
+BASEFLAGS += -fno-strict-aliasing -fno-strict-overflow
 ARCHFLAG += -march=i686 -mtune=generic -msse -msse2 -msse3
 
 ifeq ($(DBG_FLGS),1)
 	OPTFLAGS = -O0 -g
 else
 	OPTFLAGS = -O2 -fomit-frame-pointer -g
-	OPTFLAGS += -funsafe-math-optimizations
-	LTOFLAGS = -flto -fvisibility=hidden
-	LINKFLAGS += ${OPTFLAGS} ${LTOFLAGS}
 endif
 
 INCLUDES = -I"./metamod" \
@@ -89,10 +87,10 @@ distclean:
 #	${CPP} ${CPPFLAGS} -funroll-loops -c $< -o $@
 
 %.o: %.cpp
-	${CPP} ${CPPFLAGS} ${LTOFLAGS} -c $< -o $@
+	${CPP} ${CPPFLAGS} -c $< -o $@
 
 %.o: %.c
-	${CPP} ${CFLAGS} ${LTOFLAGS} -c $< -o $@
+	${CPP} ${CFLAGS} -c $< -o $@
 
 depend: Rules.depend
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ##
 ## compiling under ubuntu:
-##  for compiling linux: make 
+##  for compiling linux: make
 ##  for compiling win32: make OSTYPE=win32
 ##
 
@@ -41,7 +41,7 @@ INCLUDES = -I"./metamod" \
 	-I"./pm_shared"
 
 CFLAGS = ${BASEFLAGS} ${OPTFLAGS} ${ARCHFLAG} ${INCLUDES}
-CPPFLAGS = -fno-rtti -fno-exceptions ${CFLAGS} 
+CPPFLAGS = -fno-rtti -fno-exceptions ${CFLAGS}
 
 SRC = 	bot.cpp \
 	bot_chat.cpp \
@@ -66,7 +66,7 @@ SRC = 	bot.cpp \
 
 OBJ = $(SRC:%.cpp=%.o)
 
-${TARGET}${DLLEND}: zlib/libz.a ${OBJ} 
+${TARGET}${DLLEND}: zlib/libz.a ${OBJ}
 	${CPP} -o $@ ${OBJ} zlib/libz.a ${LINKFLAGS}
 	cp $@ addons/jk_botti/dlls/
 
@@ -74,7 +74,7 @@ zlib/libz.a:
 	(cd zlib; AR="${AR}" RANLIB="${RANLIB}" CC="${CPP} ${OPTFLAGS} ${ARCHFLAG} ${ZLIB_OSFLAGS} -DASMV" ./configure; $(MAKE) OBJA=match.o; cd ..)
 
 clean:
-	rm -f *.o ${TARGET}${DLLEND} Rules.depend zlib/*.exe 
+	rm -f *.o ${TARGET}${DLLEND} Rules.depend zlib/*.exe
 	(cd zlib; $(MAKE) clean; cd ..)
 	rm -f zlib/Makefile
 

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,16 @@
 ##
 
 ifeq ($(OSTYPE),win32)
-	CPP = i686-w64-mingw32-gcc -m32
+	CPP = i686-w64-mingw32-g++ -m32
+	CC = i686-w64-mingw32-gcc -m32
 	AR = i686-w64-mingw32-ar rc
 	RANLIB = i686-w64-mingw32-ranlib
 	LINKFLAGS = -mdll -lm -lwsock32 -lws2_32 -Xlinker --add-stdcall-alias -s
 	DLLEND = .dll
 	ZLIB_OSFLAGS =
 else
-	CPP = gcc -m32
+	CPP = g++ -m32
+	CC = gcc -m32
 	AR = ar rc
 	RANLIB = ranlib
 	ARCHFLAG = -fPIC
@@ -65,11 +67,11 @@ SRC = 	bot.cpp \
 OBJ = $(SRC:%.cpp=%.o)
 
 ${TARGET}${DLLEND}: zlib/libz.a ${OBJ}
-	${CPP} -o $@ ${OBJ} zlib/libz.a ${LINKFLAGS}
+	${CC} -o $@ ${OBJ} zlib/libz.a ${LINKFLAGS}
 	cp $@ addons/jk_botti/dlls/
 
 zlib/libz.a:
-	(cd zlib; AR="${AR}" RANLIB="${RANLIB}" CC="${CPP} ${OPTFLAGS} ${ARCHFLAG} ${ZLIB_OSFLAGS} -DASMV" ./configure; $(MAKE) OBJA=match.o; cd ..)
+	(cd zlib; AR="${AR}" RANLIB="${RANLIB}" CC="${CC} ${OPTFLAGS} ${ARCHFLAG} ${ZLIB_OSFLAGS} -DASMV" ./configure; $(MAKE) OBJA=match.o; cd ..)
 
 clean:
 	rm -f *.o ${TARGET}${DLLEND} Rules.depend zlib/*.exe

--- a/dlls/extdll.h
+++ b/dlls/extdll.h
@@ -56,9 +56,9 @@
 #endif
 
 // Misc C-runtime library headers
-#include "stdio.h"
-#include "stdlib.h"
-#include "math.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
 
 // Header file containing definition of globalvars_t and entvars_t
 typedef int	func_t;					//


### PR DESCRIPTION
PR fixes CI/build workflow and removes potentially unsafe compiler flags and optimization that are not useful with modern computers or with modern compilers (jk_botti was developed to have good performance with 400-550Mhz Pentium 3 era processor).