### PR TITLE
Fix OP4 grapple detection

### DIFF
--- a/bot_client.cpp
+++ b/bot_client.cpp
@@ -154,6 +154,7 @@ void BotClient_Valve_CurrentWeapon(void *p, int bot_index)
 }
 
 // This message is sent when a weapon is selected.
+/* Was only needed for OP4 grapple detection (old method)
 void PlayerClient_Valve_CurrentWeapon(void *p, int player_index)
 {
    static int state = 0;   // current state machine state
@@ -186,6 +187,7 @@ void PlayerClient_Valve_CurrentWeapon(void *p, int player_index)
       }
    }
 }
+*/
 
 
 // This message is sent whenever ammo ammounts are adjusted (up or down).

--- a/bot_client.h
+++ b/bot_client.h
@@ -8,7 +8,7 @@
 void BotClient_Valve_WeaponList(void *p, int bot_index);
 
 void BotClient_Valve_CurrentWeapon(void *p, int bot_index);
-void PlayerClient_Valve_CurrentWeapon(void *p, int player_index);
+//void PlayerClient_Valve_CurrentWeapon(void *p, int player_index); // Was only needed for OP4 grapple detection (old method)
 
 void BotClient_Valve_AmmoX(void *p, int bot_index);
 

--- a/engine.cpp
+++ b/engine.cpp
@@ -270,8 +270,9 @@ static void pfnMessageBegin(int msg_dest, int msg_type, const float *pOrigin, ed
                botMsgIndex = index;       // index of bot receiving message
             }
             
-            if (msg_type == FAST_GET_USER_MSG_ID (PLID, CurWeapon, "CurWeapon", NULL))
-               botMsgFunction = PlayerClient_Valve_CurrentWeapon;
+			// Was only needed for OP4 grapple detection (old method)
+            //if (msg_type == FAST_GET_USER_MSG_ID (PLID, CurWeapon, "CurWeapon", NULL))
+               //botMsgFunction = PlayerClient_Valve_CurrentWeapon;
          }
       }
       else if (msg_dest == MSG_ALL)

--- a/player.h
+++ b/player.h
@@ -29,7 +29,7 @@ typedef struct player_s
 {
    edict_t * pEdict;
    
-   int current_weapon_id;
+   //int current_weapon_id; // Was only needed for OP4 grapple detection (old method)
 
    int last_waypoint;
 

--- a/waypoint.cpp
+++ b/waypoint.cpp
@@ -2251,7 +2251,7 @@ static void WaypointAutowaypointing(int idx, edict_t *pEntity)
       return;
    
    // moving with grapple (op4)
-   if(pEntity->v.movetype == MOVETYPE_FLY && players[idx].current_weapon_id == GEARBOX_WEAPON_GRAPPLE)
+   if(pEntity->v.movetype == MOVETYPE_FLY && pEntity->v.flags & FL_IMMUNE_LAVA)
       return;
 
    // more waypoints on ladders


### PR DESCRIPTION
Stop creation of ladder waypoints in air while autowaypoint=1 and a player uses grapple hook in OP4

```diff
-   if(pEntity->v.movetype == MOVETYPE_FLY && players[idx].current_weapon_id == GEARBOX_WEAPON_GRAPPLE)
+   if(pEntity->v.movetype == MOVETYPE_FLY && pEntity->v.flags & FL_IMMUNE_LAVA)
```

**Bug**
The [PlayerClient_Valve_CurrentWeapon](https://github.com/Bots-United/jk_botti/blob/603291ebb4492cdfada15a87a915a45dd480f4a4/bot_client.cpp#L157) function sometimes didn't correctly keep track of a player's weapon when `autowaypoint=1` and this led to creation of ladder waypoints in midair while a player used the grapple hook

![image](https://github.com/user-attachments/assets/d9a937d3-e11a-4ef0-95ba-d00e735485b6)

**Fix**
What the OP4 engine itself uses for ladder detection is the otherwise unused FL_IMMUNE_LAVA (0x80000) (1<<19) flag.
[CGrapple.cpp#L168](https://github.com/twhl-community/halflife-op4-updated/blob/bb692fc0f8294d12b021cf2b1e922936a871aae2/dlls/weapons/CGrapple.cpp#L168)
```cpp
void CGrapple::PrimaryAttack()
{
/* ... */
	if (m_pTip->GetGrappleType() > CGrappleTip::TargetClass::SMALL)
	{
		m_pPlayer->pev->movetype = MOVETYPE_FLY;
		//Tells the physics code that the player is not on a ladder - Solokiller
		m_pPlayer->pev->flags |= FL_IMMUNE_LAVA;
	}
/* ... */
}
```
[pm_shared.cpp#L617](https://github.com/twhl-community/halflife-op4-updated/blob/bb692fc0f8294d12b021cf2b1e922936a871aae2/pm_shared/pm_shared.cpp#L617)
```cpp
void PM_UpdateStepSound()
{
/* ... */
	const bool fLadder = pmove->movetype == MOVETYPE_FLY && (pmove->flags & FL_IMMUNE_LAVA) == 0; // IsOnLadder();
/* ... */
}
```
The `halflife-op4-updated` repo is a remake of the original OP4 dll so I did check with a decompiler that this functionality does indeed exist in the vanilla game (opfor.dll / opfor.so) and wasn't something that was added for the updated version
![image](https://github.com/user-attachments/assets/b76790bc-36a8-48ff-9e19-4660692dfa0b)


**Artifact**
Archive: [jk_botti_grapple_bug.zip](https://github.com/user-attachments/files/18499410/jk_botti_grapple_bug.zip)
Contains files: op4_bounce.bsp (the map where the bug occured) and op4_bounce.wpt + op4_bounce.matrix the bugged waypoint files
Note: You need to replace `MSG_ALL:MSG_ONE` with `MSG_BROADCAST:MSG_ONE_UNRELIABLE` in waypoint.cpp if you wish to view these ingame with `show_waypoints 1` as there are so many waypoints in the file that the reliable channel will otherwise overflow.
