### PR TITLE
Makefile fixes, improvements, and compiler warning suppression

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install packages
       run: sudo apt-get -y install build-essential g++-multilib gcc-mingw-w64 g++-mingw-w64
     - name: make
-      run: make
+      run: CC="gcc -m32" CXX="g++ -m32" AR="ar rc" RANLIB="ranlib" make
     - name: cleanup 1
       run: git clean -xdf
     - name: make win32

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ ifeq ($(OSTYPE),win32)
 	DLLEND = .dll
 	ZLIB_OSFLAGS =
 else
-	CXX = g++ -m32
-	CC = gcc -m32
-	AR = ar rc
-	RANLIB = ranlib
+	CXX ?= g++ -m32
+	CC ?= gcc -m32
+	AR ?= ar rc
+	RANLIB ?= ranlib
 	ARCHFLAG = -fPIC
 	LINKFLAGS = -fPIC -shared -ldl -lm -s
 	DLLEND = _i386.so


### PR DESCRIPTION
## Summary
- Rename `CPP`/`CPPFLAGS` to standard `CXX`/`CXXFLAGS` — old names conflicted with zlib sub-build's use of `CPP` (C Preprocessor)
- Fix zlib sub-build to pass full CC with flags to both configure and make, preventing command-line overrides from stripping `-fPIC` and other flags
- Suppress `-Wclass-memaccess` (memset on HL SDK structs with Vector) and `-Wold-style-definition` (bundled zlib K&R C)
- Add `-fvisibility=hidden` and `-fno-semantic-interposition` for better codegen
- Use `?=` conditional assignment for Linux toolchain defaults, update CI to pass toolchain vars explicitly

## Test plan
- [x] Linux cross-compile with `i686-linux-gnu` toolchain: clean build, zero warnings
- [x] Win32 cross-compile with `i686-w64-mingw32` toolchain: clean build, zero warnings