### PR TITLE
Derive version from git tags instead of hardcoded version.h

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,28 @@ on:
       - 'v*'
 
 jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      ver_major: ${{ steps.parse.outputs.VER_MAJOR }}
+      ver_minor: ${{ steps.parse.outputs.VER_MINOR }}
+      ver_note: ${{ steps.parse.outputs.VER_NOTE }}
+    steps:
+      - name: Parse version from tag
+        id: parse
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          if [[ "$TAG" =~ ^v([0-9]+)\.([0-9]+)(.*)$ ]]; then
+            echo "VER_MAJOR=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "VER_MINOR=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+            echo "VER_NOTE=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Invalid tag format '$TAG', expected v<int>.<int><string>"
+            exit 1
+          fi
+
   build-linux:
+    needs: validate-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,7 +36,7 @@ jobs:
       - name: Install packages
         run: sudo apt-get -y install build-essential g++-multilib
       - name: Build
-        run: CC="gcc -m32" CXX="g++ -m32" AR="ar rc" RANLIB="ranlib" make -j4
+        run: CC="gcc -m32" CXX="g++ -m32" AR="ar rc" RANLIB="ranlib" make -j4 VER_MAJOR=${{ needs.validate-tag.outputs.ver_major }} VER_MINOR=${{ needs.validate-tag.outputs.ver_minor }} VER_NOTE=${{ needs.validate-tag.outputs.ver_note }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -23,13 +44,14 @@ jobs:
           path: jk_botti_mm_i386.so
 
   build-windows:
+    needs: validate-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install packages
         run: sudo apt-get -y update && sudo apt-get -y install gcc-mingw-w64 g++-mingw-w64
       - name: Build
-        run: make -j4 OSTYPE=win32
+        run: make -j4 OSTYPE=win32 VER_MAJOR=${{ needs.validate-tag.outputs.ver_major }} VER_MINOR=${{ needs.validate-tag.outputs.ver_minor }} VER_NOTE=${{ needs.validate-tag.outputs.ver_note }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -37,7 +59,7 @@ jobs:
           path: jk_botti_mm.dll
 
   release:
-    needs: [build-linux, build-windows]
+    needs: [validate-tag, build-linux, build-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,14 @@ else
 	ZLIB_OSFLAGS = -DZ_PREFIX
 endif
 
+VER_MAJOR ?= 0
+VER_MINOR ?= 0
+VER_NOTE ?= git$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
+VERFLAGS = -DVER_MAJOR=$(VER_MAJOR) -DVER_MINOR=$(VER_MINOR) -DVER_NOTE=\"$(VER_NOTE)\"
+
 TARGET = jk_botti_mm
-BASEFLAGS = -Wall -Wno-write-strings -Wno-class-memaccess
+BASEFLAGS = -Wall -Wno-write-strings -Wno-class-memaccess ${VERFLAGS}
 BASEFLAGS += -fno-strict-aliasing -fno-strict-overflow
 BASEFLAGS += -fvisibility=hidden
 ARCHFLAG += -march=i686 -mtune=generic -msse -msse2 -msse3 -mincoming-stack-boundary=2

--- a/dll.cpp
+++ b/dll.cpp
@@ -24,7 +24,6 @@
 #include "bot_skill.h"
 #include "bot_weapons.h"
 #include "bot_sound.h"
-#include "version.h"
 #include "player.h"
 #include "bot_config_init.h"
 

--- a/version.h
+++ b/version.h
@@ -1,3 +1,0 @@
-#define VER_MAJOR 1
-#define VER_MINOR 44
-#define VER_NOTE "beta1"


### PR DESCRIPTION
## Summary
- Delete `version.h` and inject `VER_MAJOR`/`VER_MINOR`/`VER_NOTE` as compiler flags from the Makefile
- Dev builds default to `0.00git<hash>`, release builds get the version parsed from the git tag
- Release workflow validates tag format (`v<int>.<int><string>`) and passes parsed components to build jobs

## Test plan
- [x] CI build passes with default `0.00git<hash>` version
- [x] Local build with `VER_MAJOR=1 VER_MINOR=44 VER_NOTE=beta1` produces correct version
- [x] Release tag `v0.01test3` parses correctly and builds with `0.01test3`
- [x] Invalid release tag format fails the validate-tag job