### PR TITLE
Fix undefined behavior from left-shifting signed int

### DIFF
--- a/bot.cpp
+++ b/bot.cpp
@@ -1277,7 +1277,7 @@ static void BotFindItem( bot_t &pBot )
                if(found)
                {
                   //does player have this weapon
-                  if(pEdict->v.weapons & (1<<pSelect[select_index].iId))
+                  if(pEdict->v.weapons & (1u<<pSelect[select_index].iId))
                   {
                      // is ammo low?
                      if(BotPrimaryAmmoLow(pBot, pSelect[select_index]) == AMMO_LOW)

--- a/bot_weapons.cpp
+++ b/bot_weapons.cpp
@@ -428,7 +428,7 @@ void BotSelectAttack(bot_t &pBot, const bot_weapon_select_t &select, qboolean &u
 qboolean BotIsCarryingWeapon(bot_t &pBot, int weapon_id)
 {
    // is the bot carrying this weapon?
-   return((pBot.pEdict->v.weapons & (1 << weapon_id)) == (1 << weapon_id));
+   return((pBot.pEdict->v.weapons & (1u << weapon_id)) == (1u << weapon_id));
 }
 
 // 

--- a/waypoint.h
+++ b/waypoint.h
@@ -36,7 +36,7 @@
 #define W_FL_LIFT_END    (1<<15) /* handled otherwise as normal waypoint except only one incoming path from lift-start,
                                     other incoming paths are ignored (at creating time of other waypoints). */
 
-#define W_FL_DELETED     (1<<31) /* used by waypoint allocation code */
+#define W_FL_DELETED     (1u<<31) /* used by waypoint allocation code */
 
 
 #define WAYPOINT_VERSION 5


### PR DESCRIPTION
## Summary
- Change `(1<<31)` to `(1u<<31)` for `W_FL_DELETED` in `waypoint.h` — always UB since it shifts a signed int into the sign bit
- Change `(1<<weapon_id)` to `(1u<<weapon_id)` in `bot.cpp` and `bot_weapons.cpp` — UB if weapon_id ever reaches 31 (currently max is 25 but no bounds check)

## Test plan
- [x] Linux build passes clean (no warnings)
- [x] Win32 cross-compile passes clean
- [x] All 52 unit tests pass