### PR TITLE
Improve neuralnet/geneticalg experimental code

### DIFF
--- a/geneticalg.cpp
+++ b/geneticalg.cpp
@@ -13,421 +13,429 @@ extern float RANDOM_FLOAT2(float flLow, float flHigh);
 
 static int get_random_int(int x,int y)
 {
-	return RANDOM_LONG2(x, y);
+   return RANDOM_LONG2(x, y);
 }
 
 // return random value in range 0 < n < 1
 static double get_random(void)
 {
-	return RANDOM_FLOAT2(0.0, 1.0);
+   return RANDOM_FLOAT2(0.0, 1.0);
 }
 
 // return random value in range -1 < n < 1
 static double get_random_weight(void)
 {
-	return get_random() - get_random();
+   return get_random() - get_random();
 }
 
 /******************************************************************* CGenome */
 void CGenome::copy_from(const CGenome &from)
 {
-	int i;
+   int i;
 
-	for (i = 0; i < m_genome_length; i++)
-		m_genes[i] = from.m_genes[i];
+   for (i = 0; i < m_genome_length; i++)
+      m_genes[i] = from.m_genes[i];
 
-	m_fitness = from.m_fitness;
+   m_fitness = from.m_fitness;
 }
 
 /*************************************************************** CPopulation */
 CPopulation::CPopulation(int population_size, int genome_length):
-		m_pop_size(population_size),
-		m_individuals(NULL),
-		m_genome_length(genome_length),
-		m_pool_size(0),
-		m_genepool(NULL)
+      m_pop_size(population_size),
+      m_individuals(NULL),
+      m_genome_length(genome_length),
+      m_pool_size(0),
+      m_genepool(NULL)
 {
-	int i;
+   int i;
 
-	// check for integer overflow in pool_size calculation
-	if (population_size <= 0 || genome_length <= 0 ||
-	    population_size > INT_MAX / genome_length)
-		return;
+   // check for integer overflow in pool_size calculation
+   if (population_size <= 0 || genome_length <= 0 ||
+       population_size > INT_MAX / genome_length)
+      return;
 
-	m_pool_size = population_size * genome_length;
+   m_pool_size = population_size * genome_length;
 
-	m_individuals = new CGenome[m_pop_size];
-	m_genepool = (double *)calloc(1, sizeof(double) * m_pool_size);
-	if (!m_genepool)
-		return;
+   m_individuals = new CGenome[m_pop_size];
+   m_genepool = (double *)calloc(1, sizeof(double) * m_pool_size);
+   if (!m_genepool)
+      return;
 
-	for (i = 0; i < m_pop_size; i++)
-		m_individuals[i] = CGenome(&m_genepool[i * m_genome_length], m_genome_length, 0.0);
+   for (i = 0; i < m_pop_size; i++)
+      m_individuals[i] = CGenome(&m_genepool[i * m_genome_length], m_genome_length, 0.0);
 
-	for (i = 0; i < m_pool_size; i++)
-		m_genepool[i] = get_random_weight();
+   for (i = 0; i < m_pool_size; i++)
+      m_genepool[i] = get_random_weight();
 }
 
 void CPopulation::free_mem(void)
 {
-	if (m_individuals) {
-		delete[] m_individuals;
-		m_individuals = NULL;
-	}
+   if (m_individuals) {
+      delete[] m_individuals;
+      m_individuals = NULL;
+   }
 
-	if (m_genepool) {
-		free(m_genepool);
-		m_genepool = NULL;
-	}
+   if (m_genepool) {
+      free(m_genepool);
+      m_genepool = NULL;
+   }
+}
+
+void CPopulation::swap(CPopulation &other)
+{
+   CPopulation tmp;
+
+   // move this -> tmp
+   tmp.m_pop_size = m_pop_size;
+   tmp.m_individuals = m_individuals;
+   tmp.m_genome_length = m_genome_length;
+   tmp.m_pool_size = m_pool_size;
+   tmp.m_genepool = m_genepool;
+
+   // move other -> this
+   m_pop_size = other.m_pop_size;
+   m_individuals = other.m_individuals;
+   m_genome_length = other.m_genome_length;
+   m_pool_size = other.m_pool_size;
+   m_genepool = other.m_genepool;
+
+   // move tmp -> other
+   other.m_pop_size = tmp.m_pop_size;
+   other.m_individuals = tmp.m_individuals;
+   other.m_genome_length = tmp.m_genome_length;
+   other.m_pool_size = tmp.m_pool_size;
+   other.m_genepool = tmp.m_genepool;
+
+   // null out tmp so its destructor doesn't free anything
+   tmp.m_individuals = NULL;
+   tmp.m_genepool = NULL;
 }
 
 CGenome *CPopulation::get_fittest_individual(void)
 {
-	double highest;
-	int highest_idx;
-	int i;
+   double highest;
+   int highest_idx;
+   int i;
 
-	if (m_pop_size == 0)
-		return NULL;
+   if (m_pop_size == 0)
+      return NULL;
 
-	highest = m_individuals[0].m_fitness;
-	highest_idx = 0;
+   highest = m_individuals[0].m_fitness;
+   highest_idx = 0;
 
-	for (i = 1; i < m_pop_size; i++) {
-		if (highest < m_individuals[i].m_fitness) {
-			highest = m_individuals[i].m_fitness;
-			highest_idx = i;
-		}
-	}
+   for (i = 1; i < m_pop_size; i++) {
+      if (highest < m_individuals[i].m_fitness) {
+         highest = m_individuals[i].m_fitness;
+         highest_idx = i;
+      }
+   }
 
-	return &m_individuals[highest_idx];
+   return &m_individuals[highest_idx];
 }
 
 /********************************************************* CGeneticAlgorithm */
 int CGeneticAlgorithm::get_crossover_interleave(int num_genes)
 {
-	if (m_crossover_interleave > num_genes)
-		return num_genes;
+   if (m_crossover_interleave > num_genes)
+      return num_genes;
 
-	if (m_crossover_interleave < 1)
-		return get_random_int(1, num_genes + 1);
+   if (m_crossover_interleave < 1)
+      return get_random_int(1, num_genes + 1);
 
-	return m_crossover_interleave;
+   return m_crossover_interleave;
 }
 
 void CGeneticAlgorithm::crossover(CGenome &parent1, CGenome &parent2, CGenome &child1, CGenome &child2)
 {
-	int num_genes = parent1.length();
-	int i, j;
+   int num_genes = parent1.length();
+   int i, j;
 
-	if (&parent1 == &parent2 || get_random() > m_crossover_rate) {
-		child1.copy_from(parent1);
-		child2.copy_from(parent2);
-		return;
-	}
+   if (&parent1 == &parent2 || get_random() > m_crossover_rate) {
+      child1.copy_from(parent1);
+      child2.copy_from(parent2);
+      return;
+   }
 
-	// split genome into chromosomes
-	int gene_pos = 0;
-	int num_chromos = get_crossover_interleave(num_genes);
-	int num_genes_per_chromo = num_genes / num_chromos;
-	int num_genes_last_chromo = num_genes - num_chromos * num_genes_per_chromo;
+   // split genome into chromosomes
+   int gene_pos = 0;
+   int num_chromos = get_crossover_interleave(num_genes);
+   int num_genes_per_chromo = num_genes / num_chromos;
+   int num_genes_last_chromo = num_genes - num_chromos * num_genes_per_chromo;
 
-	for (i = 0; i < num_chromos; i++, gene_pos += num_genes_per_chromo) {
-		int cp = get_random_int(0, num_genes_per_chromo - 1);
+   for (i = 0; i < num_chromos; i++, gene_pos += num_genes_per_chromo) {
+      int cp = get_random_int(0, num_genes_per_chromo - 1);
 
-		// create new chromosome
-		for (j = 0; j < cp; j++) {
-			child1.m_genes[gene_pos + j] = parent1.m_genes[gene_pos + j];
-			child2.m_genes[gene_pos + j] = parent2.m_genes[gene_pos + j];
-		}
+      // create new chromosome
+      for (j = 0; j < cp; j++) {
+         child1.m_genes[gene_pos + j] = parent1.m_genes[gene_pos + j];
+         child2.m_genes[gene_pos + j] = parent2.m_genes[gene_pos + j];
+      }
 
-		for (j = cp; j < num_genes_per_chromo; j++)
-		{
-			child1.m_genes[gene_pos + j] = parent2.m_genes[gene_pos + j];
-			child2.m_genes[gene_pos + j] = parent1.m_genes[gene_pos + j];
-		}
-	}
+      for (j = cp; j < num_genes_per_chromo; j++)
+      {
+         child1.m_genes[gene_pos + j] = parent2.m_genes[gene_pos + j];
+         child2.m_genes[gene_pos + j] = parent1.m_genes[gene_pos + j];
+      }
+   }
 
-	if (num_genes_last_chromo > 0) {
-		int cp = get_random_int(0, num_genes_last_chromo - 1);
+   if (num_genes_last_chromo > 0) {
+      int cp = get_random_int(0, num_genes_last_chromo - 1);
 
-		// create new chromosome
-		for (j = 0; j < cp; j++) {
-			child1.m_genes[gene_pos + j] = parent1.m_genes[gene_pos + j];
-			child2.m_genes[gene_pos + j] = parent2.m_genes[gene_pos + j];
-		}
+      // create new chromosome
+      for (j = 0; j < cp; j++) {
+         child1.m_genes[gene_pos + j] = parent1.m_genes[gene_pos + j];
+         child2.m_genes[gene_pos + j] = parent2.m_genes[gene_pos + j];
+      }
 
-		for (j = cp; j < num_genes_last_chromo; j++)
-		{
-			child1.m_genes[gene_pos + j] = parent2.m_genes[gene_pos + j];
-			child2.m_genes[gene_pos + j] = parent1.m_genes[gene_pos + j];
-		}
-	}
+      for (j = cp; j < num_genes_last_chromo; j++)
+      {
+         child1.m_genes[gene_pos + j] = parent2.m_genes[gene_pos + j];
+         child2.m_genes[gene_pos + j] = parent1.m_genes[gene_pos + j];
+      }
+   }
 
-	/*
-	// use fitness of parent which has it lowest
-	child1.m_fitness = parent1.m_fitness < parent2.m_fitness ? parent1.m_fitness : parent2.m_fitness;
-	child2.m_fitness = parent1.m_fitness < parent2.m_fitness ? parent1.m_fitness : parent2.m_fitness;
-	*/
-	child1.m_fitness = 0.0;
-	child2.m_fitness = 0.0;
+   /*
+   // use fitness of parent which has it lowest
+   child1.m_fitness = parent1.m_fitness < parent2.m_fitness ? parent1.m_fitness : parent2.m_fitness;
+   child2.m_fitness = parent1.m_fitness < parent2.m_fitness ? parent1.m_fitness : parent2.m_fitness;
+   */
+   child1.m_fitness = 0.0;
+   child2.m_fitness = 0.0;
 }
 
 void CGeneticAlgorithm::mutate(CGenome &individual)
 {
-	int num_genes = m_population->get_genome_length();
-	int i;
+   int num_genes = m_population->get_genome_length();
+   int i;
 
-	// traverse the chromosome and mutate each weight dependent on the mutation rate
-	for (i = 0; i < num_genes; i++)	{
-		//do we perturb this gene
-		if (get_random() < m_mutation_rate) {
-			//add or subtract a small value to the gene
-		//	individual.m_genes[i] += get_random_weight() * m_max_perturbation;
+   // traverse the chromosome and mutate each weight dependent on the mutation rate
+   for (i = 0; i < num_genes; i++)  {
+      //do we perturb this gene
+      if (get_random() < m_mutation_rate) {
+         //add or subtract a small value to the gene
+      // individual.m_genes[i] += get_random_weight() * m_max_perturbation;
 
-			if (fabs(individual.m_genes[i]) > 1.0)
-				individual.m_genes[i] += get_random_weight() * fabs(individual.m_genes[i]) * m_max_perturbation;
-			else
-				individual.m_genes[i] += get_random_weight() * m_max_perturbation;
-		}
-	}
+         if (fabs(individual.m_genes[i]) > 1.0)
+            individual.m_genes[i] += get_random_weight() * fabs(individual.m_genes[i]) * m_max_perturbation;
+         else
+            individual.m_genes[i] += get_random_weight() * m_max_perturbation;
+      }
+   }
 }
 
 CGenome *CGeneticAlgorithm::get_individual_random_weighted(void)
 {
-	int i;
-	double fitness_pos = 0.0;
+   int i;
+   double fitness_pos = 0.0;
 
-	// offset fitness so worst individual has effective fitness 0
-	// (roulette wheel selection requires non-negative values)
-	double offset = m_worst_fitness < 0 ? -m_worst_fitness : 0;
-	double total = m_total_fitness + offset * m_population->get_size();
+   // offset fitness so worst individual has effective fitness 0
+   // (roulette wheel selection requires non-negative values)
+   double offset = m_worst_fitness < 0 ? -m_worst_fitness : 0;
+   double total = m_total_fitness + offset * m_population->get_size();
 
-	// if all individuals have equal fitness, fall back to uniform random
-	if (total <= 0.0)
-		return get_individual_random();
+   // if all individuals have equal fitness, fall back to uniform random
+   if (total <= 0.0)
+      return get_individual_random();
 
-	double slice = get_random() * total;
+   double slice = get_random() * total;
 
-	for (i = 0; i < m_population->get_size(); i++) {
-		fitness_pos += m_population->get_fitness_of(i) + offset;
+   for (i = 0; i < m_population->get_size(); i++) {
+      fitness_pos += m_population->get_fitness_of(i) + offset;
 
-		if (fitness_pos >= slice)
-			return m_population->get_individual(i);
-	}
+      if (fitness_pos >= slice)
+         return m_population->get_individual(i);
+   }
 
-	return m_population->get_individual(m_population->get_size() - 1);
+   return m_population->get_individual(m_population->get_size() - 1);
 }
 
 CGenome *CGeneticAlgorithm::get_individual_random(void)
 {
-	return m_population->get_individual(get_random_int(0, m_population->get_size()-1));
+   return m_population->get_individual(get_random_int(0, m_population->get_size()-1));
 }
 
 int CGeneticAlgorithm::grab_num_best(const int num_best, const int num_copies, CPopulation &population, int pop_pos)
 {
-	int i, j, count = 0;
-	CGenome *elite;
-	CGenome *target;
+   int i, j, count = 0;
+   CGenome *elite;
+   CGenome *target;
 
-	// add the required amount of copies of the n most fittest to the supplied vector
-	for (i = 0; i < num_best && i < m_population->get_size(); i++) {
-		for (j = 0; j < num_copies; j++) {
-			int eidx = m_population->get_size() - 1 - i;
-			int tidx = pop_pos + count;
+   // add the required amount of copies of the n most fittest to the supplied vector
+   for (i = 0; i < num_best && i < m_population->get_size(); i++) {
+      for (j = 0; j < num_copies; j++) {
+         int eidx = m_population->get_size() - 1 - i;
+         int tidx = pop_pos + count;
 
-			if (tidx >= population.get_size())
-				return population.get_size();
+         if (tidx >= population.get_size())
+            return population.get_size();
 
-			elite = m_population->get_individual(eidx);
-			target = population.get_individual(tidx);
+         elite = m_population->get_individual(eidx);
+         target = population.get_individual(tidx);
 
-			target->copy_from(*elite);
-			target->m_fitness = 0.0;
-			count++;
-		}
-	}
+         target->copy_from(*elite);
+         target->m_fitness = 0.0;
+         count++;
+      }
+   }
 
-	return pop_pos + count;
+   return pop_pos + count;
 }
 
 int CGeneticAlgorithm::add_random_genome(CPopulation &population, int pop_pos)
 {
-	int i, j, count = 0;
-	CGenome *target;
+   int i, j, count = 0;
+   CGenome *target;
 
-	for (i = 0; i < m_num_new_random; i++) {
-		if (pop_pos + count >= population.get_size())
-			return population.get_size();
+   for (i = 0; i < m_num_new_random; i++) {
+      if (pop_pos + count >= population.get_size())
+         return population.get_size();
 
-		target = population.get_individual(pop_pos + count);
+      target = population.get_individual(pop_pos + count);
 
-		for (j = 0; j < target->length(); j++)
-			 target->m_genes[j] = get_random_weight();
+      for (j = 0; j < target->length(); j++)
+          target->m_genes[j] = get_random_weight();
 
-		count++;
-	}
+      count++;
+   }
 
-	return pop_pos + count;
+   return pop_pos + count;
 }
 
 void CGeneticAlgorithm::calculate_fitness_values(void)
 {
-	int i;
-	double highest;
-	double lowest;
+   int i;
+   double highest;
+   double lowest;
 
-	m_total_fitness = 0;
+   m_total_fitness = 0;
 
-	highest = m_population->get_fitness_of(0);
-	m_fittest_individual = 0;
-	m_best_fitness = highest;
+   highest = m_population->get_fitness_of(0);
+   m_fittest_individual = 0;
+   m_best_fitness = highest;
 
-	lowest = m_population->get_fitness_of(0);	m_worst_fitness = lowest;
+   lowest = m_population->get_fitness_of(0);
+   m_worst_fitness = lowest;
 
-	m_total_fitness = m_population->get_fitness_of(0);
+   m_total_fitness = m_population->get_fitness_of(0);
 
-	for (i = 1; i < m_population->get_size(); i++) {
-		// update fittest if necessary
-		if (m_population->get_fitness_of(i) > highest) {
-			highest = m_population->get_fitness_of(i);
-			m_fittest_individual = i;
-			m_best_fitness = highest;
-		}
+   for (i = 1; i < m_population->get_size(); i++) {
+      // update fittest if necessary
+      if (m_population->get_fitness_of(i) > highest) {
+         highest = m_population->get_fitness_of(i);
+         m_fittest_individual = i;
+         m_best_fitness = highest;
+      }
 
-		// update worst if necessary
-		if (m_population->get_fitness_of(i) < lowest) {			lowest = m_population->get_fitness_of(i);			m_worst_fitness = lowest;		}
-		m_total_fitness += m_population->get_fitness_of(i);
-	}
+      // update worst if necessary
+      if (m_population->get_fitness_of(i) < lowest) {
+         lowest = m_population->get_fitness_of(i);
+         m_worst_fitness = lowest;
+      }
+      m_total_fitness += m_population->get_fitness_of(i);
+   }
 
-	m_average_fitness = m_total_fitness / m_population->get_size();
+   m_average_fitness = m_total_fitness / m_population->get_size();
 }
 
 void CGeneticAlgorithm::reset_fitness_values(void)
 {
-	m_total_fitness = 0;
-	m_best_fitness = 0;
-	m_worst_fitness = 9999999999.9;
-	m_average_fitness = 0;
+   m_total_fitness = 0;
+   m_best_fitness = 0;
+   m_worst_fitness = 9999999999.9;
+   m_average_fitness = 0;
 }
 
-int CGeneticAlgorithm::fitness_sort(const CGenome *a, const CGenome *b)
+static int fitness_sort(const void *va, const void *vb)
 {
-	/*
-	if (a->m_fitness < b->m_fitness)
-		return -1;
-	if (a->m_fitness > b->m_fitness)
-		return 1;
-	return 0;
-	*/
-	return (a->m_fitness > b->m_fitness) - (a->m_fitness < b->m_fitness);
+   const CGenome *a = (const CGenome *)va;
+   const CGenome *b = (const CGenome *)vb;
+   return (a->m_fitness > b->m_fitness) - (a->m_fitness < b->m_fitness);
 }
 
 CPopulation *CGeneticAlgorithm::epoch(CPopulation &old_pop, CPopulation &new_pop)
 {
-	int i, new_pos = 0;
-	double *tmp_child_mem = NULL;
-	CGenome tmp_child;
+   int i, new_pos = 0;
+   double *tmp_child_mem = NULL;
+   CGenome tmp_child;
 
-	if (old_pop.get_size() != new_pop.get_size()) {
-		printf("CGeneticAlgorithm::epoch(): ERROR, different size populations\n");
-		return NULL;
-	}
+   if (old_pop.get_size() != new_pop.get_size()) {
+      printf("CGeneticAlgorithm::epoch(): ERROR, different size populations\n");
+      return NULL;
+   }
 
-	if (old_pop.get_genome_length() != new_pop.get_genome_length()) {
-		printf("CGeneticAlgorithm::epoch(): ERROR, different size genomes\n");
-		return NULL;
-	}
+   if (old_pop.get_genome_length() != new_pop.get_genome_length()) {
+      printf("CGeneticAlgorithm::epoch(): ERROR, different size genomes\n");
+      return NULL;
+   }
 
-	m_generation++;
+   m_generation++;
 
-	// assign the given population to the classes population
-	m_population = &old_pop;
+   // assign the given population to the classes population
+   m_population = &old_pop;
 
-	// reset the appropriate variables
-	reset_fitness_values();
+   // reset the appropriate variables
+   reset_fitness_values();
 
-	// sort the population (for scaling and elitism)
-	qsort(m_population->get_individual(0), m_population->get_size(), sizeof(CGenome), (int(*)(const void*, const void*))&CGeneticAlgorithm::fitness_sort);
+   // sort the population (for scaling and elitism)
+   qsort(m_population->get_individual(0), m_population->get_size(), sizeof(CGenome), fitness_sort);
 
-	// calculate best, worst, average and total fitness
-	calculate_fitness_values();
+   // calculate best, worst, average and total fitness
+   calculate_fitness_values();
 
 /*
-	printf(" best: %f\n", m_best_fitness);
-	printf("  avg: %f\n", m_average_fitness);
-	printf("worst: %f\n", m_worst_fitness);
-	printf("total: %f\n", m_total_fitness);
+   printf(" best: %f\n", m_best_fitness);
+   printf("  avg: %f\n", m_average_fitness);
+   printf("worst: %f\n", m_worst_fitness);
+   printf("total: %f\n", m_total_fitness);
 
-	for (i = 0; i < old_pop.get_size(); i++)
-		printf(" fitness[%i]: %f\n", i, old_pop.get_fitness_of(i));
+   for (i = 0; i < old_pop.get_size(); i++)
+      printf(" fitness[%i]: %f\n", i, old_pop.get_fitness_of(i));
 */
 
-	// now to add a little elitism we shall add in some copies of the fittest genomes.
-	new_pos = grab_num_best(m_num_elite, m_num_copies_elite, new_pop, new_pos);
+   // now to add a little elitism we shall add in some copies of the fittest genomes.
+   new_pos = grab_num_best(m_num_elite, m_num_copies_elite, new_pop, new_pos);
 
-	// add some completely new creatures to generate new genes
-	new_pos = add_random_genome(new_pop, new_pos);
+   // add some completely new creatures to generate new genes
+   new_pos = add_random_genome(new_pop, new_pos);
 
-	// repeat until a new population is generated
-	for (i = new_pos; i < new_pop.get_size(); i++)
-	{
-		CGenome *parent1, *parent2, *child1, *child2;
+   // repeat until a new population is generated
+   for (i = new_pos; i < new_pop.get_size(); i++)
+   {
+      CGenome *parent1, *parent2, *child1, *child2;
 
-		parent1 = get_individual_random();
-		parent2 = get_individual_random_weighted();
+      parent1 = get_individual_random();
+      parent2 = get_individual_random_weighted();
 
-		// get target genomes
-		child1 = new_pop.get_individual(i);
-		if (++i >= new_pop.get_size()) {
-			// use temporary
-			if (!tmp_child_mem)
-				tmp_child_mem = (double *)malloc(sizeof(double) * parent1->length());
-			if (!tmp_child_mem)
-				break;
+      // get target genomes
+      child1 = new_pop.get_individual(i);
+      if (++i >= new_pop.get_size()) {
+         // use temporary
+         if (!tmp_child_mem)
+            tmp_child_mem = (double *)malloc(sizeof(double) * parent1->length());
+         if (!tmp_child_mem)
+            break;
 
-			tmp_child = CGenome(tmp_child_mem, parent1->length(), 0.0);
-			child2 = &tmp_child;
-		} else
-			child2 = new_pop.get_individual(i);
+         tmp_child = CGenome(tmp_child_mem, parent1->length(), 0.0);
+         child2 = &tmp_child;
+      } else
+         child2 = new_pop.get_individual(i);
 
-		crossover(*parent1, *parent2, *child1, *child2);
+      crossover(*parent1, *parent2, *child1, *child2);
 
-		mutate(*child1);
-		mutate(*child2);
+      mutate(*child1);
+      mutate(*child2);
 
-		child1->m_fitness = 0.0;
-		child2->m_fitness = 0.0;
-	}
+      child1->m_fitness = 0.0;
+      child2->m_fitness = 0.0;
+   }
 
-	m_population = &new_pop;
+   m_population = &new_pop;
 
-	if (tmp_child_mem)
-		free(tmp_child_mem);
+   if (tmp_child_mem)
+      free(tmp_child_mem);
 
-	// sort the population (for scaling and elitism)
-	qsort(m_population->get_individual(0), m_population->get_size(), sizeof(CGenome), (int(*)(const void*, const void*))&CGeneticAlgorithm::fitness_sort);
+   // sort the population (for scaling and elitism)
+   qsort(m_population->get_individual(0), m_population->get_size(), sizeof(CGenome), fitness_sort);
 
-	return m_population;
+   return m_population;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/geneticalg.h
+++ b/geneticalg.h
@@ -1,119 +1,127 @@
+#ifndef GENETICALG_H
+#define GENETICALG_H
+
 #include "new_baseclass.h"
 
 /******************************************************************* CGenome */
 class CGenome : public class_new_baseclass {
 public:
-	int m_genome_length;
-	double *m_genes;
+   int m_genome_length;
+   double *m_genes;
 
-	double m_fitness;
+   double m_fitness;
 
-	CGenome(void): m_genome_length(0), m_genes(NULL), m_fitness(-9999999999.9) {}
-	CGenome(double in_genes[], int genome_length, double fitness): m_genome_length(genome_length), m_genes(in_genes), m_fitness(fitness) {}
+   CGenome(void): m_genome_length(0), m_genes(NULL), m_fitness(-9999999999.9) {}
+   CGenome(double in_genes[], int genome_length, double fitness): m_genome_length(genome_length), m_genes(in_genes), m_fitness(fitness) {}
 
-	void copy_from(const CGenome &from);
+   void copy_from(const CGenome &from);
 
-	int length(void) const { return m_genome_length; }
+   int length(void) const { return m_genome_length; }
 };
 
 /*************************************************************** CPopulation */
 class CPopulation : public class_new_baseclass {
 private:
-	int m_pop_size;
-	CGenome *m_individuals;
+   int m_pop_size;
+   CGenome *m_individuals;
 
-	int m_genome_length;
+   int m_genome_length;
 
-	int m_pool_size;
-	double *m_genepool;
+   int m_pool_size;
+   double *m_genepool;
+
+   // prevent copying (owns allocated buffers)
+   CPopulation(const CPopulation &);
+   CPopulation &operator=(const CPopulation &);
 
 public:
-	CPopulation(void): m_pop_size(0), m_individuals(NULL), m_genome_length(0), m_pool_size(0), m_genepool(NULL) {}
-	CPopulation(int population_size, int genome_length);
+   CPopulation(void): m_pop_size(0), m_individuals(NULL), m_genome_length(0), m_pool_size(0), m_genepool(NULL) {}
+   CPopulation(int population_size, int genome_length);
+   ~CPopulation(void) { free_mem(); }
 
-	void free_mem(void);
+   void free_mem(void);
+   void swap(CPopulation &other);
 
-	int get_size(void) const { return m_pop_size; }
-	int get_genome_length(void) const { return m_genome_length; }
-	double get_fitness_of(int i) const { return m_individuals[i].m_fitness; }
-	CGenome *get_individual(int i) { return &m_individuals[i]; }
-	CGenome *get_fittest_individual(void);
+   int get_size(void) const { return m_pop_size; }
+   int get_genome_length(void) const { return m_genome_length; }
+   double get_fitness_of(int i) const { return m_individuals[i].m_fitness; }
+   CGenome *get_individual(int i) { return &m_individuals[i]; }
+   CGenome *get_fittest_individual(void);
 };
 
 /********************************************************* CGeneticAlgorithm */
 class CGeneticAlgorithm : public class_new_baseclass {
 private:
-	// population
-	CPopulation *m_population;
+   // population
+   CPopulation *m_population;
 
-	// total, best, average and worst fitness of population
-	double m_total_fitness;
-	double m_best_fitness;
-	double m_average_fitness;
-	double m_worst_fitness;
+   // total, best, average and worst fitness of population
+   double m_total_fitness;
+   double m_best_fitness;
+   double m_average_fitness;
+   double m_worst_fitness;
 
-	// keeps track of the best genome
-	int m_fittest_individual;
+   // keeps track of the best genome
+   int m_fittest_individual;
 
-	int m_num_elite;
-	int m_num_copies_elite;
+   int m_num_elite;
+   int m_num_copies_elite;
 
-	int m_num_new_random;
+   int m_num_new_random;
 
-	// probability that a gene bits will mutate (~0.05 - 0.3)
-	double m_mutation_rate;
-	double m_max_perturbation;
+   // probability that a gene bits will mutate (~0.05 - 0.3)
+   double m_mutation_rate;
+   double m_max_perturbation;
 
-	// probability of chromosones crossing over bits (~0.7)
-	double m_crossover_rate;
+   // probability of chromosones crossing over bits (~0.7)
+   double m_crossover_rate;
 
-	// use interleaving for genome? 1 = one chromosome, 2 = two chromosomes, etc per genome
-	int m_crossover_interleave;
+   // use interleaving for genome? 1 = one chromosome, 2 = two chromosomes, etc per genome
+   int m_crossover_interleave;
 
-	// generation counter
-	int m_generation;
+   // generation counter
+   int m_generation;
 
-	void crossover(CGenome &parent1, CGenome &parent2, CGenome &child1, CGenome &child2);
-	void mutate(CGenome &individual);
-	CGenome *get_individual_random_weighted(void);
-	CGenome *get_individual_random(void);
+   void crossover(CGenome &parent1, CGenome &parent2, CGenome &child1, CGenome &child2);
+   void mutate(CGenome &individual);
+   CGenome *get_individual_random_weighted(void);
+   CGenome *get_individual_random(void);
 
-	// use to introduce elitism
-	int grab_num_best(const int num_best, const int num_copies, CPopulation &population, int pop_pos);
+   // use to introduce elitism
+   int grab_num_best(const int num_best, const int num_copies, CPopulation &population, int pop_pos);
 
-	// use to introduce randomness
-	int add_random_genome(CPopulation &population, int pop_pos);
+   // use to introduce randomness
+   int add_random_genome(CPopulation &population, int pop_pos);
 
-	void calculate_fitness_values(void);
-	void reset_fitness_values(void);
+   void calculate_fitness_values(void);
+   void reset_fitness_values(void);
 
-	int get_crossover_interleave(int num_genes);
-
-	static int fitness_sort(const CGenome *a, const CGenome *b);
+   int get_crossover_interleave(int num_genes);
 
 public:
-	CGeneticAlgorithm(double mutation_rate, double crossover_rate, int crossover_interleave = 0):
-		m_population(NULL),
-		m_total_fitness(0),
-		m_best_fitness(0),
-		m_average_fitness(0),
-		m_worst_fitness(9999999999.9),
-		m_fittest_individual(0),
-		m_num_elite(1),
-		m_num_copies_elite(2),
-		m_num_new_random(4),
-		m_mutation_rate(mutation_rate),
-		m_max_perturbation(0.3),
-		m_crossover_rate(crossover_rate),
-		m_crossover_interleave(crossover_interleave),
-		m_generation(1)
-	{
-	}
+   CGeneticAlgorithm(double mutation_rate, double crossover_rate, int crossover_interleave = 0):
+      m_population(NULL),
+      m_total_fitness(0),
+      m_best_fitness(0),
+      m_average_fitness(0),
+      m_worst_fitness(9999999999.9),
+      m_fittest_individual(0),
+      m_num_elite(1),
+      m_num_copies_elite(2),
+      m_num_new_random(4),
+      m_mutation_rate(mutation_rate),
+      m_max_perturbation(0.3),
+      m_crossover_rate(crossover_rate),
+      m_crossover_interleave(crossover_interleave),
+      m_generation(1)
+   {
+   }
 
-	CPopulation *epoch(CPopulation &old_population, CPopulation &new_population);
+   CPopulation *epoch(CPopulation &old_population, CPopulation &new_population);
 
-	CPopulation *get_population(void) { return m_population; }
+   CPopulation *get_population(void) { return m_population; }
 
-	int get_generation() const { return m_generation; }
+   int get_generation() const { return m_generation; }
 };
 
+#endif // GENETICALG_H

--- a/neuralnet.cpp
+++ b/neuralnet.cpp
@@ -10,11 +10,11 @@
 
 // Manual branch optimization for GCC 3.0.0 and newer
 #if !defined(__GNUC__) || __GNUC__ < 3
-	#define likely(x) (x)
-	#define unlikely(x) (x)
+   #define likely(x) (x)
+   #define unlikely(x) (x)
 #else
-	#define likely(x) __builtin_expect((long int)!!(x), true)
-	#define unlikely(x) __builtin_expect((long int)!!(x), false)
+   #define likely(x) __builtin_expect((long int)!!(x), true)
+   #define unlikely(x) __builtin_expect((long int)!!(x), false)
 #endif
 
 extern void fast_random_seed(unsigned int seed);
@@ -23,25 +23,25 @@ extern float RANDOM_FLOAT2(float flLow, float flHigh);
 
 static int get_random_int(int x,int y)
 {
-	return RANDOM_LONG2(x, y);
+   return RANDOM_LONG2(x, y);
 }
 
 // return random value in range 0 < n < 1
 static double get_random(void)
 {
-	return RANDOM_FLOAT2(0.0, 1.0);
+   return RANDOM_FLOAT2(0.0, 1.0);
 }
 
 // return random value in range -1 < n < 1
 static double get_random_weight(void)
 {
-	return get_random() - get_random();
+   return get_random() - get_random();
 }
 
 /******************************************************************* CNeuron */
 CNeuron::CNeuron(int num_inputs, double in_weights[]):
-	m_num_inputs(num_inputs + 1),
-	m_weights(in_weights)
+   m_num_inputs(num_inputs + 1),
+   m_weights(in_weights)
 {
 }
 
@@ -49,542 +49,302 @@ CNeuron::CNeuron(int num_inputs, double in_weights[]):
 // returns -1 on overflow
 int CNeuron::calc_needed_weights(int num_inputs)
 {
-	if (num_inputs < 0 || num_inputs >= INT_MAX)
-		return -1;
-	return num_inputs + 1;
+   if (num_inputs < 0 || num_inputs >= INT_MAX)
+      return -1;
+   return num_inputs + 1;
 }
 
 /************************************************************** CNeuronLayer */
 CNeuronLayer::CNeuronLayer(int num_neurons, int num_inputs_per_neuron, CNeuron in_neurons[], double in_weights[]):
-	m_num_neurons(num_neurons),
-	m_neurons(in_neurons)
+   m_num_neurons(num_neurons),
+   m_neurons(in_neurons)
 {
-	int i, weight_pos;
+   int i, weight_pos;
 
-	weight_pos = 0;
-	for (i = 0; i < m_num_neurons; i++) {
-		m_neurons[i] = CNeuron(num_inputs_per_neuron, &in_weights[weight_pos]);
-		weight_pos += CNeuron::calc_needed_weights(num_inputs_per_neuron);
-	}
+   weight_pos = 0;
+   for (i = 0; i < m_num_neurons; i++) {
+      m_neurons[i] = CNeuron(num_inputs_per_neuron, &in_weights[weight_pos]);
+      weight_pos += CNeuron::calc_needed_weights(num_inputs_per_neuron);
+   }
 }
 
 // returns -1 on overflow
 int CNeuronLayer::calc_needed_weights(int num_neurons, int num_inputs_per_neuron)
 {
-	int per_neuron = CNeuron::calc_needed_weights(num_inputs_per_neuron);
-	if (per_neuron < 0 || num_neurons <= 0 || per_neuron > INT_MAX / num_neurons)
-		return -1;
-	return per_neuron * num_neurons;
+   int per_neuron = CNeuron::calc_needed_weights(num_inputs_per_neuron);
+   if (per_neuron < 0 || num_neurons <= 0 || per_neuron > INT_MAX / num_neurons)
+      return -1;
+   return per_neuron * num_neurons;
 }
 
 /**************************************************************** CNeuralNet */
 CNeuralNet::CNeuralNet(int num_inputs, int num_outputs, int num_hidden, int num_neurons_per_hidden):
-	m_num_inputs(num_inputs),
-	m_num_outputs(num_outputs),
-	m_num_hidden(num_hidden),
-	m_num_neurons_per_hidden(num_neurons_per_hidden),
-	m_widest_weight_array(0),
-	m_widest_layer(0),
-	m_bias(-1.0),
-	m_activation_response(1.0),
-	m_num_layers(num_hidden + 1), // hidden + output
-	m_layers(NULL),
-	m_num_weights(0),
-	m_weights(NULL),
-	m_num_neurons(0),
-	m_neurons(NULL)
+   m_num_inputs(num_inputs),
+   m_num_outputs(num_outputs),
+   m_num_hidden(num_hidden),
+   m_num_neurons_per_hidden(num_neurons_per_hidden),
+   m_widest_weight_array(0),
+   m_widest_layer(0),
+   m_bias(-1.0),
+   m_num_layers(num_hidden + 1), // hidden + output
+   m_layers(NULL),
+   m_num_weights(0),
+   m_weights(NULL),
+   m_neurons(NULL),
+   m_run_tmp1(NULL),
+   m_run_tmp2(NULL)
 {
-	int i, j, weight_pos, neuron_pos, total_neurons;
+   int i, j, weight_pos, neuron_pos, total_neurons;
 
-	if (m_num_layers == 0)
-		return;
+   if (m_num_layers == 0)
+      return;
 
-	// calculated number of needed weights in neural network
-	if (m_num_layers == 1) {
-		m_num_weights = CNeuronLayer::calc_needed_weights(m_num_outputs, m_num_inputs);
-	} else {
-		int w1 = CNeuronLayer::calc_needed_weights(m_num_neurons_per_hidden, m_num_inputs);
-		int w2 = CNeuronLayer::calc_needed_weights(m_num_neurons_per_hidden, m_num_neurons_per_hidden);
-		int w3 = CNeuronLayer::calc_needed_weights(m_num_outputs, m_num_neurons_per_hidden);
-		int inner_layers = m_num_layers - 2;
-		int w2_total;
+   // calculated number of needed weights in neural network
+   if (m_num_layers == 1) {
+      m_num_weights = CNeuronLayer::calc_needed_weights(m_num_outputs, m_num_inputs);
+   } else {
+      int w1 = CNeuronLayer::calc_needed_weights(m_num_neurons_per_hidden, m_num_inputs);
+      int w2 = CNeuronLayer::calc_needed_weights(m_num_neurons_per_hidden, m_num_neurons_per_hidden);
+      int w3 = CNeuronLayer::calc_needed_weights(m_num_outputs, m_num_neurons_per_hidden);
+      int inner_layers = m_num_layers - 2;
+      int w2_total;
 
-		if (w1 < 0 || w2 < 0 || w3 < 0)
-			return;
-		if (inner_layers > 0 && w2 > INT_MAX / inner_layers)
-			return;
-		w2_total = w2 * inner_layers;
-		if (w1 > INT_MAX - w2_total || w1 + w2_total > INT_MAX - w3)
-			return;
-		m_num_weights = w1 + w2_total + w3;
-	}
-	if (m_num_weights < 0)
-		return;
+      if (w1 < 0 || w2 < 0 || w3 < 0)
+         return;
+      if (inner_layers > 0 && w2 > INT_MAX / inner_layers)
+         return;
+      w2_total = w2 * inner_layers;
+      if (w1 > INT_MAX - w2_total || w1 + w2_total > INT_MAX - w3)
+         return;
+      m_num_weights = w1 + w2_total + w3;
+   }
+   if (m_num_weights < 0)
+      return;
 
-	// create network wide weight array
-	m_weights = (double *)calloc(1, sizeof(double) * m_num_weights);
-	if (!m_weights)
-		return;
-	reset_weights_random();
+   // create network wide weight array
+   m_weights = (double *)calloc(1, sizeof(double) * m_num_weights);
+   if (!m_weights)
+      return;
+   reset_weights_random();
 
-	// create network wide neuron array (check for overflow)
-	if (m_num_hidden > 0 && m_num_neurons_per_hidden > INT_MAX / m_num_hidden)
-		return;
-	total_neurons = m_num_neurons_per_hidden * m_num_hidden;
-	if (m_num_outputs > INT_MAX - total_neurons)
-		return;
-	total_neurons += m_num_outputs;
-	m_neurons = (CNeuron *)calloc(1, sizeof(CNeuron) * total_neurons);
-	if (!m_neurons)
-		return;
+   // create network wide neuron array (check for overflow)
+   if (m_num_hidden > 0 && m_num_neurons_per_hidden > INT_MAX / m_num_hidden)
+      return;
+   total_neurons = m_num_neurons_per_hidden * m_num_hidden;
+   if (m_num_outputs > INT_MAX - total_neurons)
+      return;
+   total_neurons += m_num_outputs;
+   m_neurons = (CNeuron *)calloc(1, sizeof(CNeuron) * total_neurons);
+   if (!m_neurons)
+      return;
 
-	// create neuron layers
-	m_layers = new CNeuronLayer[m_num_layers];
+   // create neuron layers
+   m_layers = new CNeuronLayer[m_num_layers];
 
-	if (m_num_layers == 1) {
-		// create output layer
-		m_layers[0] = CNeuronLayer(m_num_outputs, m_num_inputs, m_neurons, m_weights);
-	} else {
-		// create first hidden layer
-		m_layers[0] = CNeuronLayer(m_num_neurons_per_hidden, m_num_inputs, m_neurons, m_weights);
-		weight_pos = CNeuronLayer::calc_needed_weights(m_num_neurons_per_hidden, m_num_inputs);
-		neuron_pos = m_num_neurons_per_hidden;
+   if (m_num_layers == 1) {
+      // create output layer
+      m_layers[0] = CNeuronLayer(m_num_outputs, m_num_inputs, m_neurons, m_weights);
+   } else {
+      // create first hidden layer
+      m_layers[0] = CNeuronLayer(m_num_neurons_per_hidden, m_num_inputs, m_neurons, m_weights);
+      weight_pos = CNeuronLayer::calc_needed_weights(m_num_neurons_per_hidden, m_num_inputs);
+      neuron_pos = m_num_neurons_per_hidden;
 
-		// create inner hidden layers
-		for (i = 1; i < m_num_layers - 1; i++) {
-			m_layers[i] = CNeuronLayer(m_num_neurons_per_hidden, m_num_neurons_per_hidden, &m_neurons[neuron_pos], &m_weights[weight_pos]);
-			weight_pos += CNeuronLayer::calc_needed_weights(m_num_neurons_per_hidden, m_num_neurons_per_hidden);
-			neuron_pos += m_num_neurons_per_hidden;
-		}
+      // create inner hidden layers
+      for (i = 1; i < m_num_layers - 1; i++) {
+         m_layers[i] = CNeuronLayer(m_num_neurons_per_hidden, m_num_neurons_per_hidden, &m_neurons[neuron_pos], &m_weights[weight_pos]);
+         weight_pos += CNeuronLayer::calc_needed_weights(m_num_neurons_per_hidden, m_num_neurons_per_hidden);
+         neuron_pos += m_num_neurons_per_hidden;
+      }
 
-		// create output layer
-		m_layers[m_num_layers - 1] = CNeuronLayer(m_num_outputs, m_num_neurons_per_hidden, &m_neurons[neuron_pos], &m_weights[weight_pos]);
-	}
+      // create output layer
+      m_layers[m_num_layers - 1] = CNeuronLayer(m_num_outputs, m_num_neurons_per_hidden, &m_neurons[neuron_pos], &m_weights[weight_pos]);
+   }
 
-	// get widest layer and weight array
-	m_widest_weight_array = 0;
-	m_widest_layer = 0;
-	for (i = 0; i < m_num_layers; i++) {
-		if (m_widest_layer < m_layers[i].get_num_neurons())
-			m_widest_layer = m_layers[i].get_num_neurons();
-		for (j = 0; j < m_layers[i].get_num_neurons(); j++)
-			if (m_widest_weight_array < m_layers[i].m_neurons[j].get_num_inputs())
-				m_widest_weight_array = m_layers[i].m_neurons[j].get_num_inputs();
-	}
+   // get widest layer and weight array
+   m_widest_weight_array = 0;
+   m_widest_layer = 0;
+   for (i = 0; i < m_num_layers; i++) {
+      if (m_widest_layer < m_layers[i].get_num_neurons())
+         m_widest_layer = m_layers[i].get_num_neurons();
+      for (j = 0; j < m_layers[i].get_num_neurons(); j++)
+         if (m_widest_weight_array < m_layers[i].m_neurons[j].get_num_inputs())
+            m_widest_weight_array = m_layers[i].m_neurons[j].get_num_inputs();
+   }
+
+   // allocate temporary buffers for run()
+   m_run_tmp1 = (double *)calloc(m_widest_layer, sizeof(double));
+   m_run_tmp2 = (double *)calloc(m_widest_layer, sizeof(double));
 }
 
 // destructor, release memory
 CNeuralNet::~CNeuralNet(void)
 {
-	if (m_weights) {
-		free(m_weights);
-		m_weights = NULL;
-	}
+   if (m_weights) {
+      free(m_weights);
+      m_weights = NULL;
+   }
 
-	if (m_layers) {
-		delete[] m_layers;
-		m_layers = NULL;
-	}
+   if (m_layers) {
+      delete[] m_layers;
+      m_layers = NULL;
+   }
 
-	if (m_neurons) {
-		free(m_neurons);
-		m_neurons = NULL;
-	}
+   if (m_neurons) {
+      free(m_neurons);
+      m_neurons = NULL;
+   }
+
+   if (m_run_tmp1) {
+      free(m_run_tmp1);
+      m_run_tmp1 = NULL;
+   }
+
+   if (m_run_tmp2) {
+      free(m_run_tmp2);
+      m_run_tmp2 = NULL;
+   }
 }
 
 // reset neuron weights to random
 void CNeuralNet::reset_weights_random(void)
 {
-	int i;
+   int i;
 
-	for (i = 0; i < m_num_weights; i++)
-		m_weights[i] = get_random_weight();
+   for (i = 0; i < m_num_weights; i++)
+      m_weights[i] = get_random_weight();
 }
 
 // weights must have array size of m_num_weights
 double *CNeuralNet::get_weights(double weights[]) const
 {
-	int i;
+   int i;
 
-	for (i = 0; i < m_num_weights; i++)
-		weights[i] = m_weights[i];
+   for (i = 0; i < m_num_weights; i++)
+      weights[i] = m_weights[i];
 
-	return weights;
+   return weights;
 }
 
 // weights must have array size of m_num_weights, allocated by caller
 void CNeuralNet::put_weights(double weights[])
 {
-	int i;
+   int i;
 
-	for (i = 0; i < m_num_weights; i++)
-		m_weights[i] = weights[i];
+   for (i = 0; i < m_num_weights; i++)
+      m_weights[i] = weights[i];
 }
 
 static double expanded_sigmoid(double activation, double response = 1.0)
 {
-	double s;
+   double s;
 
-	// input activation is -1..1, convert to 0..1
-	activation = (activation + 1) / 2;
+   // input activation is -1..1, convert to 0..1
+   activation = (activation + 1) / 2;
 
-	s = 1 / ( 1 + exp(-activation / response));
+   s = 1 / ( 1 + exp(-activation / response));
 
-	// s is 0..1, convert to -1..1
-	return (s * 2) - 1;
+   // s is 0..1, convert to -1..1
+   return (s * 2) - 1;
 }
 
 double *CNeuralNet::run(const double inputs[], double outputs[]) const
 {
-	return run(inputs, outputs, NULL);
+   return run(inputs, outputs, NULL);
 }
 
 double *CNeuralNet::run(const double inputs[], double outputs[], const double scales[]) const
 {
-	int i;
-	double *ptr1, *ptr2, *out;
+   int i;
+   double *out;
 
-	if (m_num_layers < 1)
-		return NULL;
+   if (m_num_layers < 1)
+      return NULL;
 
-	ptr1 = (double*)alloca(m_widest_layer * sizeof(double));
-	ptr2 = (double*)alloca(m_widest_layer * sizeof(double));
+   out = run_internal(inputs, m_run_tmp1, m_run_tmp2);
 
-	out = run_internal(inputs, outputs, ptr1, ptr2);
+   if (scales)
+      for (i = 0; i < m_num_outputs; i++)
+         outputs[i] = out[i] * scales[i];
+   else
+      for (i = 0; i < m_num_outputs; i++)
+         outputs[i] = out[i];
 
-	if (scales)
-		for (i = 0; i < m_num_outputs; i++)
-			outputs[i] = out[i] * scales[i];
-	else
-		for (i = 0; i < m_num_outputs; i++)
-			outputs[i] = out[i];
-
-	return outputs;
+   return outputs;
 }
 
 // run neural network, inputs must have array size of m_num_inputs
 // and output must have array size of m_num_outputs
 // ptr1 and ptr2 are temporary buffers
-double *CNeuralNet::run_internal(const double orig_inputs[], double target_outputs[], double *ptr1, double *ptr2) const
+double *CNeuralNet::run_internal(const double orig_inputs[], double *ptr1, double *ptr2) const
 {
-	int i, j, k, in_size, out_size = 0;
-	double *outputs = NULL;
-	const double *inputs;
-	bool ptr1_used = false, ptr2_used = false;
+   int i, j, k, in_size, out_size = 0;
+   double *outputs = NULL;
+   const double *inputs;
+   bool ptr1_used = false, ptr2_used = false;
 
-	inputs = orig_inputs;
-	in_size = m_num_inputs;
+   inputs = orig_inputs;
+   in_size = m_num_inputs;
 
-	// walk through all layers
-	for (i = 0; i < m_num_layers; i++) {
-		const CNeuronLayer &cur_layer = m_layers[i];
+   // walk through all layers
+   for (i = 0; i < m_num_layers; i++) {
+      const CNeuronLayer &cur_layer = m_layers[i];
 
-		if (likely(i > 0)) {
-			// free old input slot
-			ptr1_used = !(inputs == ptr1) & ptr1_used;
-			ptr2_used = !(inputs == ptr2) & ptr2_used;
+      if (likely(i > 0)) {
+         // free old input slot
+         ptr1_used = !(inputs == ptr1) & ptr1_used;
+         ptr2_used = !(inputs == ptr2) & ptr2_used;
 
-			inputs = outputs;
-			in_size = out_size;
-		}
+         inputs = outputs;
+         in_size = out_size;
+      }
 
-		out_size = cur_layer.get_num_neurons();
+      out_size = cur_layer.get_num_neurons();
 
-		// get memory slot for output array
-		if (!ptr1_used) {
-			outputs = ptr1;
-			ptr1_used = true;
-		} else {
-			outputs = ptr2;
-			ptr2_used = true;
-		}
+      // get memory slot for output array
+      if (!ptr1_used) {
+         outputs = ptr1;
+         ptr1_used = true;
+      } else {
+         outputs = ptr2;
+         ptr2_used = true;
+      }
 
-		// walk through all neurons in current layer
-		for (j = 0; j < cur_layer.get_num_neurons(); j++) {
-			const CNeuron &cur_neuron = cur_layer.m_neurons[j];
-			double sum = 0;
+      // walk through all neurons in current layer
+      for (j = 0; j < cur_layer.get_num_neurons(); j++) {
+         const CNeuron &cur_neuron = cur_layer.m_neurons[j];
+         double sum = 0;
 
-			// for each weight
-			for (k = 0; k < cur_neuron.get_num_inputs() - 1; k++)
-				//sum the weights x inputs
-				sum += cur_neuron.m_weights[k] * inputs[k];
+         // for each weight
+         for (k = 0; k < cur_neuron.get_num_inputs() - 1; k++)
+            //sum the weights x inputs
+            sum += cur_neuron.m_weights[k] * inputs[k];
 
-			// add bias
-			sum += cur_neuron.m_weights[cur_neuron.get_num_inputs() - 1] * m_bias;
+         // add bias
+         sum += cur_neuron.m_weights[cur_neuron.get_num_inputs() - 1] * m_bias;
 
-			outputs[j] = expanded_sigmoid(sum);
-		}
-	}
+         outputs[j] = expanded_sigmoid(sum);
+      }
+   }
 
-	return outputs;
+   return outputs;
 }
 
 void CNeuralNet::print(void) const
 {
-	int i, j, k;
+   int i, j, k;
 
-	for (i = 0; i < m_num_layers; i++) {
-		printf("layer [%i] neurons[%i]:\n", i, m_layers[i].get_num_neurons());
+   for (i = 0; i < m_num_layers; i++) {
+      printf("layer [%i] neurons[%i]:\n", i, m_layers[i].get_num_neurons());
 
-		for (j = 0; j < m_layers[i].get_num_neurons(); j++) {
-			printf("  neuron [%i:%i] inputs[%i]:\n", i, j, m_layers[i].m_neurons[j].get_num_inputs());
+      for (j = 0; j < m_layers[i].get_num_neurons(); j++) {
+         printf("  neuron [%i:%i] inputs[%i]:\n", i, j, m_layers[i].m_neurons[j].get_num_inputs());
 
-			printf("    ");
-			for (k = 0; k < m_layers[i].m_neurons[j].get_num_inputs(); k++) {
-				printf("[%f] ", m_layers[i].m_neurons[j].m_weights[k]);
-			}
-			printf("\n");
-		}
-	}
+         printf("    ");
+         for (k = 0; k < m_layers[i].m_neurons[j].get_num_inputs(); k++) {
+            printf("[%f] ", m_layers[i].m_neurons[j].m_weights[k]);
+         }
+         printf("\n");
+      }
+   }
 }
-
-/*********************************************************** testing section */
-/*
-double training_inputs[4][2] = {{0, 0}, {0, 1}, {1, 0}, {1, 1}};
-int training_outputs[4] = {0, 1, 2, 3};
-
-int main()
-{
-	int i, j, k;
-	int rnd_idx;
-	double input[2] = {1, -1};
-	double output[1];
-	double diff = 0;
-
-	fast_random_seed(time(0) ^ (long)&diff ^ (long)&main);
-
-	CNeuralNet *nnet = new CNeuralNet(2, 1, 5, 5);
-	CPopulation population = CPopulation(20, nnet->get_num_weights());
-	CGeneticAlgorithm genalg(0.2, 0.7, -1);
-
-	printf("ok\n");
-	fflush(stdout);
-
-	CGenome *best_genome;
-
-	for (k = 0; k < 1000; k++) {
-		//printf("k: %i\n", k);
-		for (i = 0; i < 500; i++) {
-			//printf(" i: %i\n", i);
-			for (j = 0; j < population.get_size(); j++) {
-				//printf("  j: %i\n", j);
-				rnd_idx = get_random_int(0, 3);
-				CGenome *genome = population.get_individual(j);
-
-				nnet->put_weights(genome->m_genes);
-				nnet->run(training_inputs[rnd_idx], output);
-
-				diff = fabs(output[0] - training_outputs[rnd_idx]);
-
-				//printf("   output: %f\n", output[0]);
-				//printf("should be: %f\n", training_outputs[rnd_idx]);
-				//printf("     diff: %f\n", diff);
-				if (diff < 4.0)
-					genome->m_fitness += 4.0 - diff;
-			}
-		}
-
-		if (!(k % 100)) {
-			CGenome *genome = population.get_fittest_individual();
-
-			nnet->put_weights(genome->m_genes);
-			nnet->run(input, output);
-
-			printf("generation: %i\n", genalg.get_generation());
-			printf("best fitness: %f\n", genome->m_fitness);
-
-			nnet->run(training_inputs[0], output);
-			printf("input: %f, %f\n", training_inputs[0][0], training_inputs[0][1]);
-			printf("output: %f\n", output[0]);
-
-			nnet->run(training_inputs[1], output);
-			printf("input: %f, %f\n", training_inputs[1][0], training_inputs[1][1]);
-			printf("output: %f\n", output[0]);
-
-			nnet->run(training_inputs[2], output);
-			printf("input: %f, %f\n", training_inputs[2][0], training_inputs[2][1]);
-			printf("output: %f\n", output[0]);
-
-			nnet->run(training_inputs[3], output);
-			printf("input: %f, %f\n", training_inputs[3][0], training_inputs[3][1]);
-			printf("output: %f\n", output[0]);
-		}
-
-		if (k+1 < 1000) {
-			CPopulation new_pop = CPopulation(population.get_size(), nnet->get_num_weights());
-			genalg.epoch(population, new_pop);
-			population.free_mem();
-			population = new_pop;
-		}
-	}
-
-	CGenome *genome = population.get_fittest_individual();
-
-	nnet->put_weights(genome->m_genes);
-	nnet->run(input, output);
-
-	nnet->print();
-
-	printf("generation: %i\n", genalg.get_generation());
-	printf("best fitness: %f\n", genome->m_fitness);
-
-	nnet->run(training_inputs[0], output);
-	printf("input: %f, %f\n", training_inputs[0][0], training_inputs[0][1]);
-	printf("output: %f\n", output[0]);
-
-	nnet->run(training_inputs[1], output);
-	printf("input: %f, %f\n", training_inputs[1][0], training_inputs[1][1]);
-	printf("output: %f\n", output[0]);
-
-	nnet->run(training_inputs[2], output);
-	printf("input: %f, %f\n", training_inputs[2][0], training_inputs[2][1]);
-	printf("output: %f\n", output[0]);
-
-	nnet->run(training_inputs[3], output);
-	printf("input: %f, %f\n", training_inputs[3][0], training_inputs[3][1]);
-	printf("output: %f\n", output[0]);
-
-	delete nnet;
-}
-*/
-
-double f(double x, double y, double z) {
-	return x*x;
-	//return x*6;
-}
-
-static double scale_output(double max, double min, double output)
-{
-	// -1..+1 => max..min
-	return (max - min) * (output + 1) / 2 + min;
-}
-
-// training
-int main()
-{
-	int i, j, k;
-	int rnd_idx;
-	double input[3];
-	double output[1];
-	double scale[1] = {100};
-	double diff = 0;
-
-	fast_random_seed(time(0) ^ (long)&diff ^ (long)&main);
-
-	CNeuralNet *nnet = new CNeuralNet(1, 1, 1, 4);
-	CPopulation population = CPopulation(25, nnet->get_num_weights());
-	CGeneticAlgorithm genalg(0.2, 0.7);
-
-	printf("ok\n");
-	fflush(stdout);
-
-	CGenome *best_genome;
-
-	for (k = 0; k < 5000; k++) {
-		//printf("k: %i\n", k);
-		for (j = 0; j < population.get_size(); j++) {
-			double x, y, z, foutput;
-			CGenome *genome = population.get_individual(j);
-
-			nnet->put_weights(genome->m_genes);
-
-			for (x = -0.5; x <= 4.5; x += 1) {
-				for (y = -0.5; y <= 4.5; y += 1) {
-					for (z = -0.5; z <= 4.5; z += 1) {
-						input[0] = x;
-						input[1] = y;
-						input[2] = z;
-
-						nnet->run(input, output, scale);
-
-						foutput = f(input[0], input[1], input[2]);
-						diff = output[0] - foutput;						
-
-						genome->m_fitness += -(diff*diff)*0.0002;
-					}
-				}
-			}
-
-			//printf(" j: %i\n", j);
-			for (i = 0; i < 500; i++) {
-				//printf("  i: %i\n", i);
-				input[0] = get_random() * 5 - 0.5;
-				input[1] = get_random() * 5 - 0.5;
-				input[2] = get_random() * 5 - 0.5;
-
-				nnet->run(input, output, scale);
-
-				foutput = f(input[0], input[1], input[2]);
-				diff = output[0] - foutput;						
-
-				genome->m_fitness += -(diff*diff)*0.0001;
-
-				//diff = fabs(output[1] - sin(random_angle));
-				//if (diff < 1.0)
-				//	genome->m_fitness += 1.0 - diff;
-
-				//printf("   output: %f\n", output[0]);
-				//printf("should be: %f\n", training_outputs[rnd_idx]);
-				//printf("     diff: %f\n", diff);
-			}
-		}
-
-		if (!(k % 100)) {
-			CGenome *genome = population.get_fittest_individual();
-
-			nnet->put_weights(genome->m_genes);
-			nnet->run(input, output);
-
-			printf("generation: %i\n", genalg.get_generation());
-			printf("best fitness: %f\n", genome->m_fitness);
-
-			input[0] = 1;
-			input[1] = 2;
-			input[2] = 3;
-			nnet->run(input, output, scale);
-			printf("input: %f:%f:%f (=> %f)\n", input[0], input[1], input[2], f(input[0], input[1], input[2]));
-			printf("output: %f\n", output[0]);
-		}
-
-		if (k+1 < 5000) {
-			CPopulation new_pop = CPopulation(population.get_size(), nnet->get_num_weights());
-			genalg.epoch(population, new_pop);
-			population.free_mem();
-			population = new_pop;
-		}
-	}
-
-	CGenome *genome = population.get_fittest_individual();
-
-	nnet->put_weights(genome->m_genes);
-	nnet->run(input, output);
-
-	nnet->print();
-
-	printf("generation: %i\n", genalg.get_generation());
-	printf("best fitness: %f\n", genome->m_fitness);
-
-	for (i = 0; i < 9; i++) {
-		input[0] = i * 0.5;
-		input[1] = (9 - i) * 0.5;
-		input[2] = i % 4;
-		nnet->run(input, output, scale);
-		printf("input: %f:%f:%f (=> %f)\n", input[0], input[1], input[2], f(input[0], input[1], input[2]));
-		printf("output: %f\n", output[0]);
-	}
-
-	delete nnet;
-}
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/neuralnet.h
+++ b/neuralnet.h
@@ -1,18 +1,21 @@
+#ifndef NEURALNET_H
+#define NEURALNET_H
+
 #include "new_baseclass.h"
 
 /******************************************************************* CNeuron */
 class CNeuron : public class_new_baseclass
 {
 public:
-	int m_num_inputs;
-	double *m_weights;
+   int m_num_inputs;
+   double *m_weights;
 
-	CNeuron(void): m_num_inputs(0), m_weights(NULL) {}
-	CNeuron(int num_inputs, double in_weights[]);
+   CNeuron(void): m_num_inputs(0), m_weights(NULL) {}
+   CNeuron(int num_inputs, double in_weights[]);
 
-	int get_num_inputs(void) const { return m_num_inputs; }
+   int get_num_inputs(void) const { return m_num_inputs; }
 
-	static int calc_needed_weights(int num_inputs);
+   static int calc_needed_weights(int num_inputs);
 };
 
 /************************************************************** CNeuronLayer */
@@ -20,57 +23,63 @@ class CNeuronLayer : public class_new_baseclass
 {
 public:
 
-	int m_num_neurons;
-	CNeuron *m_neurons;
+   int m_num_neurons;
+   CNeuron *m_neurons;
 
-	CNeuronLayer(void): m_num_neurons(0), m_neurons(NULL) {}
-	CNeuronLayer(int num_neurons, int num_inputs_per_neuron, CNeuron in_neurons[], double in_weights[]);
+   CNeuronLayer(void): m_num_neurons(0), m_neurons(NULL) {}
+   CNeuronLayer(int num_neurons, int num_inputs_per_neuron, CNeuron in_neurons[], double in_weights[]);
 
-	int get_num_neurons(void) const { return m_num_neurons; }
+   int get_num_neurons(void) const { return m_num_neurons; }
 
-	static int calc_needed_weights(int num_neurons, int num_inputs_per_neuron);
+   static int calc_needed_weights(int num_neurons, int num_inputs_per_neuron);
 };
 
 /**************************************************************** CNeuralNet */
 class CNeuralNet : public class_new_baseclass
 {
 private:
-	int m_num_inputs;
-	int m_num_outputs;
-	int m_num_hidden;
-	int m_num_neurons_per_hidden;
-	int m_widest_weight_array;
-	int m_widest_layer;
+   int m_num_inputs;
+   int m_num_outputs;
+   int m_num_hidden;
+   int m_num_neurons_per_hidden;
+   int m_widest_weight_array;
+   int m_widest_layer;
 
-	double m_bias;
-	double m_activation_response;
+   double m_bias;
 
-	int m_num_layers;
-	CNeuronLayer *m_layers;
+   int m_num_layers;
+   CNeuronLayer *m_layers;
 
-	int m_num_weights;
-	double *m_weights;
+   int m_num_weights;
+   double *m_weights;
 
-	int m_num_neurons;
-	CNeuron *m_neurons;
+   CNeuron *m_neurons;
 
-	double *run_internal(const double orig_inputs[], double target_outputs[], double *ptr1, double *ptr2) const;
+   double *m_run_tmp1;
+   double *m_run_tmp2;
+
+   double *run_internal(const double orig_inputs[], double *ptr1, double *ptr2) const;
+
+   // prevent copying (pointers to internal buffers)
+   CNeuralNet(const CNeuralNet &);
+   CNeuralNet &operator=(const CNeuralNet &);
 
 public:
-	CNeuralNet(int num_inputs, int num_outputs, int num_hidden, int num_neurons_per_hidden);
-	~CNeuralNet(void);
+   CNeuralNet(int num_inputs, int num_outputs, int num_hidden, int num_neurons_per_hidden);
+   ~CNeuralNet(void);
 
-	int get_num_weights(void) const { return m_num_weights; }
-	int get_num_inputs(void) const { return m_num_inputs; }
-	int get_num_outputs(void) const { return m_num_outputs; }
+   int get_num_weights(void) const { return m_num_weights; }
+   int get_num_inputs(void) const { return m_num_inputs; }
+   int get_num_outputs(void) const { return m_num_outputs; }
 
-	void reset_weights_random(void);
-	double *get_weights(double weights[]) const;
-	void put_weights(double weights[]);
+   void reset_weights_random(void);
+   double *get_weights(double weights[]) const;
+   void put_weights(double weights[]);
 
-	double *run(const double inputs[], double outputs[]) const;
-	double *run(const double inputs[], double outputs[], const double scales[]) const;
+   double *run(const double inputs[], double outputs[]) const;
+   double *run(const double inputs[], double outputs[], const double scales[]) const;
 
-	void print(void) const;
+   void print(void) const;
 };
 
+#endif // NEURALNET_H

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,7 +23,13 @@ test_bot_combat: $(BOT_COMBAT_OBJS)
 %.o: ../%.cpp
 	${CXX} ${TEST_CXXFLAGS} -c $< -o $@
 
-ALL_TESTS = test_name_sanitize test_posdata_list test_bot_combat
+# Neural net training test
+NEURALNET_OBJS = test_neuralnet.o neuralnet.o geneticalg.o random_num.o
+
+test_neuralnet: $(NEURALNET_OBJS)
+	${CXX} -o $@ $(NEURALNET_OBJS) -lm
+
+ALL_TESTS = test_name_sanitize test_posdata_list test_bot_combat test_neuralnet
 
 all: $(ALL_TESTS)
 
@@ -31,6 +37,7 @@ run: $(ALL_TESTS)
 	./test_name_sanitize
 	./test_posdata_list
 	./test_bot_combat
+	./test_neuralnet
 
 VALGRIND = valgrind --leak-check=full --error-exitcode=1
 
@@ -38,6 +45,7 @@ valgrind: $(ALL_TESTS)
 	$(VALGRIND) ./test_name_sanitize
 	$(VALGRIND) ./test_posdata_list
 	$(VALGRIND) ./test_bot_combat
+	$(VALGRIND) ./test_neuralnet
 
 clean:
 	rm -f $(ALL_TESTS) *.o

--- a/tests/test_neuralnet.cpp
+++ b/tests/test_neuralnet.cpp
@@ -1,0 +1,211 @@
+//
+// JK_Botti - tests for neuralnet and genetic algorithm
+//
+
+#include <stdlib.h>
+#include <math.h>
+
+#include "test_common.h"
+
+#include "neuralnet.h"
+#include "geneticalg.h"
+
+extern void fast_random_seed(unsigned int seed);
+extern float RANDOM_FLOAT2(float flLow, float flHigh);
+
+// return random value in range 0 < n < 1
+static double get_random(void)
+{
+   return RANDOM_FLOAT2(0.0, 1.0);
+}
+
+// ============================================================
+// Unit tests
+// ============================================================
+
+static int test_neuralnet_construction(void)
+{
+   printf("neuralnet construction:\n");
+
+   TEST("create 1-input 1-output network");
+   CNeuralNet *nnet = new CNeuralNet(1, 1, 1, 4);
+   ASSERT_INT(nnet->get_num_inputs(), 1);
+   ASSERT_INT(nnet->get_num_outputs(), 1);
+   ASSERT_TRUE(nnet->get_num_weights() > 0);
+   PASS();
+
+   TEST("run produces output");
+   double input[1] = {0.5};
+   double output[1] = {0.0};
+   ASSERT_PTR_NOT_NULL(nnet->run(input, output));
+   PASS();
+
+   TEST("run with scale produces output");
+   double scale[1] = {10.0};
+   double output2[1] = {0.0};
+   ASSERT_PTR_NOT_NULL(nnet->run(input, output2, scale));
+   PASS();
+
+   TEST("weights round-trip");
+   int nw = nnet->get_num_weights();
+   double *w1 = (double *)malloc(nw * sizeof(double));
+   double *w2 = (double *)malloc(nw * sizeof(double));
+   nnet->get_weights(w1);
+   nnet->put_weights(w1);
+   nnet->get_weights(w2);
+   bool match = true;
+   for (int i = 0; i < nw; i++)
+      if (w1[i] != w2[i]) { match = false; break; }
+   free(w1);
+   free(w2);
+   ASSERT_TRUE(match);
+   PASS();
+
+   delete nnet;
+   return 0;
+}
+
+static int test_population(void)
+{
+   printf("population:\n");
+
+   TEST("create population");
+   CPopulation pop(10, 5);
+   ASSERT_INT(pop.get_size(), 10);
+   ASSERT_INT(pop.get_genome_length(), 5);
+   PASS();
+
+   TEST("get individual");
+   CGenome *g = pop.get_individual(0);
+   ASSERT_PTR_NOT_NULL(g);
+   ASSERT_INT(g->length(), 5);
+   PASS();
+
+   TEST("get fittest individual");
+   // set known fitness values
+   pop.get_individual(3)->m_fitness = 100.0;
+   CGenome *fittest = pop.get_fittest_individual();
+   ASSERT_PTR_EQ(fittest, pop.get_individual(3));
+   PASS();
+
+   TEST("swap populations");
+   CPopulation pop2(10, 5);
+   double gene0_a = pop.get_individual(0)->m_genes[0];
+   double gene0_b = pop2.get_individual(0)->m_genes[0];
+   pop.swap(pop2);
+   ASSERT_TRUE(pop.get_individual(0)->m_genes[0] == gene0_b);
+   ASSERT_TRUE(pop2.get_individual(0)->m_genes[0] == gene0_a);
+   PASS();
+
+   return 0;
+}
+
+// ============================================================
+// Training test: approximate f(x) = x^2 via genetic algorithm
+// ============================================================
+
+static double target_func(double x)
+{
+   return x * x;
+}
+
+static int test_training(void)
+{
+   int i, j, k;
+   double input[3];
+   double output[1];
+   double scale[1] = {100};
+   double diff;
+
+   printf("neuralnet training (f(x) = x^2):\n");
+
+   // fixed seed for reproducibility
+   fast_random_seed(42);
+
+   CNeuralNet *nnet = new CNeuralNet(1, 1, 1, 4);
+   CPopulation population(25, nnet->get_num_weights());
+   CGeneticAlgorithm genalg(0.2, 0.7);
+
+   for (k = 0; k < 1000; k++) {
+      for (j = 0; j < population.get_size(); j++) {
+         double x, foutput;
+         CGenome *genome = population.get_individual(j);
+
+         nnet->put_weights(genome->m_genes);
+
+         for (x = -0.5; x <= 4.5; x += 1) {
+            input[0] = x;
+            nnet->run(input, output, scale);
+
+            foutput = target_func(input[0]);
+            diff = output[0] - foutput;
+            genome->m_fitness += -(diff * diff) * 0.0002;
+         }
+
+         for (i = 0; i < 500; i++) {
+            input[0] = get_random() * 5 - 0.5;
+            nnet->run(input, output, scale);
+
+            foutput = target_func(input[0]);
+            diff = output[0] - foutput;
+            genome->m_fitness += -(diff * diff) * 0.0001;
+         }
+      }
+
+      if (k + 1 < 1000) {
+         CPopulation new_pop(population.get_size(), nnet->get_num_weights());
+         genalg.epoch(population, new_pop);
+         population.swap(new_pop);
+      }
+   }
+
+   CGenome *best = population.get_fittest_individual();
+   nnet->put_weights(best->m_genes);
+
+   TEST("fitness improved from initial");
+   ASSERT_TRUE(best->m_fitness > -1.0);
+   PASS();
+
+   // check trained network approximates x^2 at several points
+   double max_err = 0;
+   for (i = 0; i < 9; i++) {
+      input[0] = i * 0.5;
+      nnet->run(input, output, scale);
+      double expected = target_func(input[0]);
+      double err = fabs(output[0] - expected);
+      if (err > max_err)
+         max_err = err;
+   }
+
+   TEST("approximation error < 2.0 across test points");
+   if (max_err >= 2.0)
+      printf("(max_err=%.3f) ", max_err);
+   ASSERT_TRUE(max_err < 2.0);
+   PASS();
+
+   delete nnet;
+   return 0;
+}
+
+int main(void)
+{
+   int rc = 0;
+
+   printf("=== neuralnet tests ===\n\n");
+
+   rc |= test_neuralnet_construction();
+   printf("\n");
+   rc |= test_population();
+   printf("\n");
+   rc |= test_training();
+
+   printf("\n%d/%d tests passed.\n", tests_passed, tests_run);
+
+   if (rc || tests_passed != tests_run) {
+      printf("SOME TESTS FAILED!\n");
+      return 1;
+   }
+
+   printf("All tests passed.\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary
- Fix integer overflow issues and bugs in neuralnet/geneticalg code
- Design improvements: remove unused members, replace alloca with preallocated buffers, fix qsort UB, add RAII and copy prevention
- Add include guards, change to 3-space indentation matching project style
- Extract test code into `tests/test_neuralnet.cpp` using `test_common.h` framework with proper assertions

## Test plan
- [x] Main build unaffected (files not in Makefile)
- [x] `make test` passes with 32-bit cross-compiler (62/62 tests)
- [x] `test_neuralnet` covers construction, population, weights round-trip, and training convergence