### PR TITLE
Clean up safe_snprintf and consolidate likely/unlikely macros

### DIFF
--- a/bot.h
+++ b/bot.h
@@ -10,14 +10,7 @@
 #include <ctype.h>
 #include "safe_snprintf.h"
 
-// Manual branch optimization for GCC 3.0.0 and newer
-#if !defined(__GNUC__) || __GNUC__ < 3
-	#define likely(x) (x)
-	#define unlikely(x) (x)
-#else
-	#define likely(x) __builtin_expect((long int)!!(x), true)
-	#define unlikely(x) __builtin_expect((long int)!!(x), false)
-#endif
+#include "compiler.h"
 
 
 //

--- a/bot_inline_funcs.h
+++ b/bot_inline_funcs.h
@@ -10,14 +10,7 @@
 #include <inttypes.h>
 #include <sys/time.h>
 
-// Manual branch optimization for GCC 3.0.0 and newer
-#if !defined(__GNUC__) || __GNUC__ < 3
-	#define likely(x) (x)
-	#define unlikely(x) (x)
-#else
-	#define likely(x) __builtin_expect((long int)!!(x), true)
-	#define unlikely(x) __builtin_expect((long int)!!(x), false)
-#endif
+#include "compiler.h"
 
 //
 inline Vector GetGunPosition(edict_t *pEdict)

--- a/compiler.h
+++ b/compiler.h
@@ -1,0 +1,18 @@
+#ifndef COMPILER_H
+#define COMPILER_H
+
+// Manual branch optimization for GCC 3.0.0 and newer
+#if !defined(__GNUC__) || __GNUC__ < 3
+   #define likely(x) (x)
+   #define unlikely(x) (x)
+#else
+   #define likely(x) __builtin_expect((long int)!!(x), true)
+   #define unlikely(x) __builtin_expect((long int)!!(x), false)
+#endif
+
+// memccpy is available on POSIX (Linux glibc, mingw)
+#if defined(__linux__) || defined(_WIN32)
+   #define HAVE_MEMCCPY 1
+#endif
+
+#endif // COMPILER_H

--- a/neuralnet.cpp
+++ b/neuralnet.cpp
@@ -8,14 +8,7 @@
 #include "neuralnet.h"
 #include "geneticalg.h"
 
-// Manual branch optimization for GCC 3.0.0 and newer
-#if !defined(__GNUC__) || __GNUC__ < 3
-   #define likely(x) (x)
-   #define unlikely(x) (x)
-#else
-   #define likely(x) __builtin_expect((long int)!!(x), true)
-   #define unlikely(x) __builtin_expect((long int)!!(x), false)
-#endif
+#include "compiler.h"
 
 extern void fast_random_seed(unsigned int seed);
 extern float RANDOM_FLOAT2(float flLow, float flHigh);

--- a/random_num.cpp
+++ b/random_num.cpp
@@ -1,11 +1,4 @@
-// Manual branch optimization for GCC 3.0.0 and newer
-#if !defined(__GNUC__) || __GNUC__ < 3
-   #define likely(x) (x)
-   #define unlikely(x) (x)
-#else
-   #define likely(x) __builtin_expect((long int)!!(x), true)
-   #define unlikely(x) __builtin_expect((long int)!!(x), false)
-#endif
+#include "compiler.h"
 
 static unsigned int rnd_idnum[2] = {1, 1};
 

--- a/safe_snprintf.cpp
+++ b/safe_snprintf.cpp
@@ -4,181 +4,71 @@
 // safe_snprintf.cpp
 //
 
-#ifndef _WIN32
 #include <string.h>
-#endif
-
 #include <stdarg.h>
 #include <stdio.h>
-#include <memory.h>
-#include <malloc.h>
-#include <limits.h>
 
 #include "safe_snprintf.h"
 
-// Manual branch optimization for GCC 3.0.0 and newer
-#if !defined(__GNUC__) || __GNUC__ < 3
-	#define likely(x) (x)
-	#define unlikely(x) (x)
-#else
-	#define likely(x) __builtin_expect((long int)!!(x), true)
-	#define unlikely(x) __builtin_expect((long int)!!(x), false)
-#endif
+#include "compiler.h"
 
 // Acts very much like safevoid_snprintf(dst, dst_size, "%s", src)
 //    if src is null "(null)" is written
 //    returns dst
-char * safe_strcopy(char * dst, size_t dst_size, const char *src)
+char* safe_strcopy(char* dst, size_t dst_size, const char *src)
 {
-   size_t i;
-   
-   if(unlikely(!src))
+   if (unlikely(!dst_size))
+      return dst;
+
+   if (unlikely(!src))
       src = "(null)";
-   
-   for(i = 0; likely(src[i] != '\0') && likely(i < dst_size); i++)
-      dst[i] = src[i];
-   
-   if(likely(i < dst_size))
-   	dst[i] = '\0';
-   else if(likely(i == dst_size))
-   	dst[i-1] = '\0';
-   
+
+#ifdef HAVE_MEMCCPY
+   // memccpy copies until '\0' found or dst_size-1 bytes copied,
+   // returns NULL if '\0' was not found within the limit
+   if (!memccpy(dst, src, '\0', dst_size - 1))
+      dst[dst_size - 1] = '\0';
+#else
+   {
+      size_t i;
+
+      for (i = 0; likely(i < dst_size - 1) && likely(src[i] != '\0'); i++)
+         dst[i] = src[i];
+
+      dst[i] = '\0';
+   }
+#endif
+
    return dst;
 }
 
-#if 0
-// Microsoft's msvcrt.dll:vsnprintf is buggy and so is vsnprintf on some glibc versions.
-// We use wrapper function to fix bugs.
-//  from: http://sourceforge.net/tracker/index.php?func=detail&aid=1083721&group_id=2435&atid=102435
-int safe_vsnprintf(char* s, size_t n, const char *format, va_list src_ap) 
-{ 
-	va_list ap;
-	int res;
-	char *tmpbuf;
-	size_t bufsize = n;
-	
-	if(s && n>0)
-		s[0]=0;
-	
-	// If the format string is empty, nothing to do.
-	if(!format || !*format)
-		return(0);
-	
-	// The supplied count may be big enough. Try to use the library
-     	// vsnprintf, fixing up the case where the library function
-	// neglects to terminate with '/0'.
-	if(n > 0)
-	{
-		// A NULL destination will cause a segfault with vsnprintf.
-		// if n > 0.  Nor do we want to copy our tmpbuf to NULL later.
-		if(!s)
-			return(-1);
-		
-		va_copy(ap, src_ap);
-		res = vsnprintf(s, n, format, ap);
-		va_end(ap);
-		
-		if(res > 0) {
-			if((unsigned)res == n)
-				s[res - 1] = 0;
-	  		return(res);
-		}
-		
-		// If n is already larger than INT_MAX, increasing it won't
-		// help.
-		if(n > INT_MAX)
-			return(-1);
-		
-		// Try a larger buffer.
-		bufsize *= 2;
-	}
-	
-	if(bufsize < 1024)
-		bufsize = 1024;
-	
-	tmpbuf = (char *)malloc(bufsize * sizeof(char));
-	if(!tmpbuf)
-		return(-1);
-	
-	va_copy(ap, src_ap);
-  	res = vsnprintf(tmpbuf, bufsize, format, ap);
-  	va_end(ap);
-	
-	// The test for bufsize limit is probably not necesary
-	// with 2GB address space limit, since, in practice, malloc will
-	// fail well before INT_MAX.
-	while(res < 0 && bufsize <= INT_MAX) 
-	{
-		char * newbuf;
-		
-		bufsize *= 2;
-		newbuf = (char*)realloc(tmpbuf, bufsize * sizeof(char));
-		
-		if(!newbuf)
-			break;
-		
-		tmpbuf = newbuf;
-		
-		va_copy(ap, src_ap);
-		res = vsnprintf(tmpbuf, bufsize, format, ap);
-		va_end(ap);
-	}
-	
-	if(res > 0 && n > 0) 
-	{
-		if(n > (unsigned)res)
-			memcpy(s, tmpbuf, (res + 1) * sizeof (char));
-		else {
-			memcpy(s, tmpbuf, (n - 1) * sizeof (char));
-			s[n - 1] = 0;
-		}
-	}
-	
-	free(tmpbuf);
-	return(res);
-}
-
-int safe_snprintf(char* s, size_t n, const char* format, ...) 
+void safevoid_vsnprintf(char* s, size_t n, const char *format, va_list ap)
 {
-	int res;
-	va_list ap;
-	
-	va_start(ap, format);
-	res = safe_vsnprintf(s, n, format, ap);
-	va_end(ap);
-	
-	return(res);
-}
-#endif
+   int res;
 
-void safevoid_vsnprintf(char* s, size_t n, const char *format, va_list ap) 
-{ 
-	int res;
-	
-	if(unlikely(!s) || unlikely(n <= 0))
-		return;
-	
-	// If the format string is empty, nothing to do.
-	if(unlikely(!format) || unlikely(!*format))
-	{
-		s[0]=0;
-		return;
-	}
-	
-	res = vsnprintf(s, n, format, ap);
-	
-	// w32api returns -1 on too long write, glibc returns number of bytes it could have written if there were enough space
-	// w32api doesn't write null at all, some buggy glibc don't either
-	if(res < 0 || (size_t)res >= n)
-		s[n-1]=0;
+   if (unlikely(!s) || unlikely(!n))
+      return;
+
+   // If the format string is empty, nothing to do.
+   if (unlikely(!format) || unlikely(!*format))
+   {
+      s[0] = 0;
+      return;
+   }
+
+   res = vsnprintf(s, n, format, ap);
+
+   // w32api returns -1 on too long write, glibc returns number of bytes it could have written if there were enough space
+   // w32api doesn't write null at all, some buggy glibc don't either
+   if (unlikely(res < 0) || unlikely((size_t)res >= n))
+      s[n-1] = 0;
 }
 
-void safevoid_snprintf(char* s, size_t n, const char* format, ...) 
+void safevoid_snprintf(char* s, size_t n, const char* format, ...)
 {
-	va_list ap;
-	
-	va_start(ap, format);
-	safevoid_vsnprintf(s, n, format, ap);
-	va_end(ap);
-}
+   va_list ap;
 
+   va_start(ap, format);
+   safevoid_vsnprintf(s, n, format, ap);
+   va_end(ap);
+}

--- a/safe_snprintf.h
+++ b/safe_snprintf.h
@@ -5,7 +5,5 @@ extern char * safe_strcopy(char * dst, size_t dst_size, const char *src);
 
 extern void safevoid_snprintf(char* s, size_t n, const char* format, ...);
 extern void safevoid_vsnprintf(char* s, size_t n, const char *format, va_list ap);
-extern int safe_snprintf(char* s, size_t n, const char* format, ...);
-extern int safe_vsnprintf(char* s, size_t n, const char *format, va_list src_ap);
 
 #endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,6 +23,12 @@ test_bot_combat: $(BOT_COMBAT_OBJS)
 %.o: ../%.cpp
 	${CXX} ${TEST_CXXFLAGS} -c $< -o $@
 
+# safe_snprintf test
+SAFE_SNPRINTF_OBJS = test_safe_snprintf.o safe_snprintf.o
+
+test_safe_snprintf: $(SAFE_SNPRINTF_OBJS)
+	${CXX} -o $@ $(SAFE_SNPRINTF_OBJS)
+
 # Random number generator test
 RANDOM_NUM_OBJS = test_random_num.o random_num.o
 
@@ -35,7 +41,7 @@ NEURALNET_OBJS = test_neuralnet.o neuralnet.o geneticalg.o random_num.o
 test_neuralnet: $(NEURALNET_OBJS)
 	${CXX} -o $@ $(NEURALNET_OBJS) -lm
 
-ALL_TESTS = test_name_sanitize test_posdata_list test_bot_combat test_random_num test_neuralnet
+ALL_TESTS = test_name_sanitize test_posdata_list test_bot_combat test_safe_snprintf test_random_num test_neuralnet
 
 all: $(ALL_TESTS)
 
@@ -43,6 +49,7 @@ run: $(ALL_TESTS)
 	./test_name_sanitize
 	./test_posdata_list
 	./test_bot_combat
+	./test_safe_snprintf
 	./test_random_num
 	./test_neuralnet
 
@@ -52,6 +59,7 @@ valgrind: $(ALL_TESTS)
 	$(VALGRIND) ./test_name_sanitize
 	$(VALGRIND) ./test_posdata_list
 	$(VALGRIND) ./test_bot_combat
+	$(VALGRIND) ./test_safe_snprintf
 	$(VALGRIND) ./test_random_num
 	$(VALGRIND) ./test_neuralnet
 

--- a/tests/test_safe_snprintf.cpp
+++ b/tests/test_safe_snprintf.cpp
@@ -1,0 +1,289 @@
+//
+// JK_Botti - tests for safe_snprintf and safe_strcopy
+//
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+#include "test_common.h"
+
+#include "safe_snprintf.h"
+
+// helper: fill buffer with sentinel value
+static void fill_buf(char *buf, size_t size, char val)
+{
+   memset(buf, val, size);
+}
+
+// ============================================================
+// safe_strcopy tests
+// ============================================================
+
+static int test_strcopy_basic(void)
+{
+   char buf[64];
+
+   printf("safe_strcopy basic:\n");
+
+   TEST("copy simple string");
+   fill_buf(buf, sizeof(buf), 'X');
+   safe_strcopy(buf, sizeof(buf), "hello");
+   ASSERT_STR(buf, "hello");
+   PASS();
+
+   TEST("copy empty string");
+   fill_buf(buf, sizeof(buf), 'X');
+   safe_strcopy(buf, sizeof(buf), "");
+   ASSERT_STR(buf, "");
+   PASS();
+
+   TEST("NULL src writes (null)");
+   fill_buf(buf, sizeof(buf), 'X');
+   safe_strcopy(buf, sizeof(buf), NULL);
+   ASSERT_STR(buf, "(null)");
+   PASS();
+
+   TEST("returns dst pointer");
+   char *ret = safe_strcopy(buf, sizeof(buf), "test");
+   ASSERT_TRUE(ret == buf);
+   PASS();
+
+   return 0;
+}
+
+static int test_strcopy_truncation(void)
+{
+   char buf[8];
+
+   printf("safe_strcopy truncation:\n");
+
+   TEST("exact fit (src length == dst_size - 1)");
+   fill_buf(buf, sizeof(buf), 'X');
+   safe_strcopy(buf, 6, "hello"); // 5 chars + null = 6
+   ASSERT_STR(buf, "hello");
+   PASS();
+
+   TEST("truncation (src longer than dst_size)");
+   fill_buf(buf, sizeof(buf), 'X');
+   safe_strcopy(buf, 4, "hello");
+   ASSERT_STR(buf, "hel");
+   PASS();
+
+   TEST("dst_size 1 produces empty string");
+   fill_buf(buf, sizeof(buf), 'X');
+   safe_strcopy(buf, 1, "hello");
+   ASSERT_STR(buf, "");
+   PASS();
+
+   TEST("dst_size 2 copies one char");
+   fill_buf(buf, sizeof(buf), 'X');
+   safe_strcopy(buf, 2, "hello");
+   ASSERT_STR(buf, "h");
+   PASS();
+
+   return 0;
+}
+
+static int test_strcopy_zero_size(void)
+{
+   printf("safe_strcopy zero size:\n");
+
+   // BUG: dst_size == 0 causes write to dst[SIZE_MAX] (underflow of i-1).
+   // Use heap buffer so valgrind catches the out-of-bounds write.
+   TEST("dst_size 0 does not crash or modify buffer");
+   char *hbuf = (char *)malloc(8);
+   fill_buf(hbuf, 8, 'X');
+   safe_strcopy(hbuf, 0, "hello");
+   ASSERT_TRUE(hbuf[0] == 'X');
+   free(hbuf);
+   PASS();
+
+   TEST("dst_size 0 with NULL src does not crash");
+   hbuf = (char *)malloc(8);
+   fill_buf(hbuf, 8, 'X');
+   safe_strcopy(hbuf, 0, NULL);
+   ASSERT_TRUE(hbuf[0] == 'X');
+   free(hbuf);
+   PASS();
+
+   return 0;
+}
+
+static int test_strcopy_null_truncation(void)
+{
+   char buf[8];
+
+   printf("safe_strcopy NULL truncation:\n");
+
+   // "(null)" is 6 chars, test truncation of that
+   TEST("NULL src truncated to dst_size 4");
+   fill_buf(buf, sizeof(buf), 'X');
+   safe_strcopy(buf, 4, NULL);
+   ASSERT_STR(buf, "(nu");
+   PASS();
+
+   TEST("NULL src truncated to dst_size 1");
+   fill_buf(buf, sizeof(buf), 'X');
+   safe_strcopy(buf, 1, NULL);
+   ASSERT_STR(buf, "");
+   PASS();
+
+   return 0;
+}
+
+// ============================================================
+// safevoid_snprintf tests
+// ============================================================
+
+static int test_snprintf_basic(void)
+{
+   char buf[64];
+
+   printf("safevoid_snprintf basic:\n");
+
+   TEST("simple string format");
+   fill_buf(buf, sizeof(buf), 'X');
+   safevoid_snprintf(buf, sizeof(buf), "hello %s", "world");
+   ASSERT_STR(buf, "hello world");
+   PASS();
+
+   TEST("integer format");
+   fill_buf(buf, sizeof(buf), 'X');
+   safevoid_snprintf(buf, sizeof(buf), "%d", 42);
+   ASSERT_STR(buf, "42");
+   PASS();
+
+   TEST("empty format string");
+   fill_buf(buf, sizeof(buf), 'X');
+   safevoid_snprintf(buf, sizeof(buf), "");
+   ASSERT_STR(buf, "");
+   PASS();
+
+   TEST("NULL format string");
+   fill_buf(buf, sizeof(buf), 'X');
+   safevoid_snprintf(buf, sizeof(buf), NULL);
+   ASSERT_STR(buf, "");
+   PASS();
+
+   return 0;
+}
+
+static int test_snprintf_truncation(void)
+{
+   char buf[8];
+
+   printf("safevoid_snprintf truncation:\n");
+
+   TEST("output truncated to buffer size");
+   fill_buf(buf, sizeof(buf), 'X');
+   safevoid_snprintf(buf, 4, "hello world");
+   ASSERT_INT((int)strlen(buf), 3);
+   ASSERT_STR(buf, "hel");
+   PASS();
+
+   TEST("exact fit");
+   fill_buf(buf, sizeof(buf), 'X');
+   safevoid_snprintf(buf, 6, "hello");
+   ASSERT_STR(buf, "hello");
+   PASS();
+
+   TEST("buffer size 1 produces empty string");
+   fill_buf(buf, sizeof(buf), 'X');
+   safevoid_snprintf(buf, 1, "hello");
+   ASSERT_STR(buf, "");
+   PASS();
+
+   return 0;
+}
+
+static int test_snprintf_edge_cases(void)
+{
+   char buf[64];
+
+   printf("safevoid_snprintf edge cases:\n");
+
+   TEST("NULL buffer pointer does not crash");
+   safevoid_snprintf(NULL, 10, "hello");
+   PASS();
+
+   TEST("zero size does not crash");
+   fill_buf(buf, sizeof(buf), 'X');
+   safevoid_snprintf(buf, 0, "hello");
+   // buffer should be untouched
+   ASSERT_TRUE(buf[0] == 'X');
+   PASS();
+
+   TEST("NULL buffer with zero size does not crash");
+   safevoid_snprintf(NULL, 0, "hello");
+   PASS();
+
+   TEST("multiple format arguments");
+   safevoid_snprintf(buf, sizeof(buf), "%s=%d, %s=%d", "a", 1, "b", 2);
+   ASSERT_STR(buf, "a=1, b=2");
+   PASS();
+
+   TEST("percent literal");
+   safevoid_snprintf(buf, sizeof(buf), "100%%");
+   ASSERT_STR(buf, "100%");
+   PASS();
+
+   return 0;
+}
+
+static int test_snprintf_always_null_terminated(void)
+{
+   char buf[8];
+
+   printf("safevoid_snprintf null termination:\n");
+
+   TEST("always null-terminated when truncated");
+   // fill with non-zero to detect missing null
+   fill_buf(buf, sizeof(buf), 'Z');
+   safevoid_snprintf(buf, 4, "abcdefghij");
+   ASSERT_TRUE(buf[3] == '\0');
+   ASSERT_INT((int)strlen(buf), 3);
+   PASS();
+
+   TEST("always null-terminated at exact boundary");
+   fill_buf(buf, sizeof(buf), 'Z');
+   safevoid_snprintf(buf, 4, "abc");
+   ASSERT_TRUE(buf[3] == '\0');
+   ASSERT_STR(buf, "abc");
+   PASS();
+
+   return 0;
+}
+
+int main(void)
+{
+   int rc = 0;
+
+   printf("=== safe_snprintf tests ===\n\n");
+
+   rc |= test_strcopy_basic();
+   printf("\n");
+   rc |= test_strcopy_truncation();
+   printf("\n");
+   rc |= test_strcopy_zero_size();
+   printf("\n");
+   rc |= test_strcopy_null_truncation();
+   printf("\n");
+   rc |= test_snprintf_basic();
+   printf("\n");
+   rc |= test_snprintf_truncation();
+   printf("\n");
+   rc |= test_snprintf_edge_cases();
+   printf("\n");
+   rc |= test_snprintf_always_null_terminated();
+
+   printf("\n%d/%d tests passed.\n", tests_passed, tests_run);
+
+   if (rc || tests_passed != tests_run) {
+      printf("SOME TESTS FAILED!\n");
+      return 1;
+   }
+
+   printf("All tests passed.\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary

- **Fix safe_strcopy dst_size==0 bug**: called with size 0, the unsigned loop bound underflowed to `SIZE_MAX`, causing a wild write to `dst[-1]`. Add early return for zero size.
- **Use memccpy for safe_strcopy** when available (`HAVE_MEMCCPY`), with portable byte-loop fallback for platforms without it.
- **Fix misleading unsigned comparison** `n <= 0` in `safevoid_vsnprintf` — `n` is `size_t`, so this is just `n == 0`. Changed to `!n`.
- **Remove dead code**: `#if 0` block (`safe_vsnprintf`/`safe_snprintf`) and their declarations from `safe_snprintf.h`.
- **Remove unused includes** (`malloc.h`, `memory.h`, `limits.h`), make `string.h` unconditional.
- **Consolidate likely/unlikely macros**: move duplicated definitions from 5 files into new shared `compiler.h` header (also hosts `HAVE_MEMCCPY` detection).
- **Cosmetic**: tabs to 3-space indent, trailing whitespace, space after `if` keyword.
- **Add 26 unit tests** for `safe_strcopy` and `safevoid_snprintf` covering basic operation, truncation, edge cases, and the fixed dst_size==0 bug (uses heap buffer for valgrind detection).

## Test plan
- [x] Full project build clean (no warnings)
- [x] All 26 new tests pass
- [x] `make -C tests valgrind` passes (heap-based zero-size test catches the bug under valgrind)