### PR TITLE
Require tests to pass before creating release artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           path: jk_botti_mm.dll
 
   release-artifact:
-    needs: [build-linux, build-windows]
+    needs: [test, build-linux, build-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add `test` to the `needs` list of the `release-artifact` CI job so the release archive is only created when tests and valgrind pass, not just builds.

## Test plan
- [x] CI passes on this PR