### PR TITLE
Separate linux and win32 build output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,16 @@
 *~
 Rules.depend
-zlib/Makefile
+obj/
 
 *.o
 *.so
 *.dll
 *.exe
 *.a
-zlib/example
-zlib/minigzip
 tests/test_*
 !tests/test_*.cpp
 !tests/test_*.h
 tests/bench_*
 !tests/bench_*.cpp
 !tests/bench_*.h
-zlib/configure.log
-zlib/zlib.pc
 tmp/

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,7 @@
 # tests/Makefile
 
+ZLIB_LIB ?= ../zlib/libz.a
+
 PARENT_INCLUDES = -I"../metamod" -I"../common" -I"../dlls" -I"../engine" -I"../pm_shared"
 TEST_CXXFLAGS = ${CXXFLAGS} ${PARENT_INCLUDES} -I".."
 
@@ -56,8 +58,8 @@ test_neuralnet: $(NEURALNET_OBJS)
 # Waypoint tests (waypoint.cpp is #included in test file, not linked separately)
 WAYPOINT_OBJS = engine_mock.o test_waypoint.o bot_weapons.o util.o safe_snprintf.o random_num.o
 
-test_waypoint: $(WAYPOINT_OBJS) ../zlib/libz.a
-	${CXX} -o $@ $(WAYPOINT_OBJS) ../zlib/libz.a -lm
+test_waypoint: $(WAYPOINT_OBJS) $(ZLIB_LIB)
+	${CXX} -o $@ $(WAYPOINT_OBJS) $(ZLIB_LIB) -lm
 
 ALL_TESTS = test_name_sanitize test_posdata_list test_bot_combat test_util test_bot_chat test_safe_snprintf test_random_num test_neuralnet test_waypoint
 


### PR DESCRIPTION
## Summary
- Put object files in `obj/linux/` or `obj/win32/` based on OSTYPE so both builds can coexist without stale cross-platform objects
- Build zlib out-of-tree in `$(OBJDIR)/zlib/` using zlib's native SRCDIR support
- Pass `ZLIB_LIB` path to tests/Makefile so test_waypoint links the correct library
- Simplify `clean`/`distclean` to just `rm -rf obj`

## Test plan
- [x] `make` builds linux into `obj/linux/`, produces `jk_botti_mm_i386.so`
- [x] `make OSTYPE=win32` builds win32 into `obj/win32/`, produces `jk_botti_mm.dll`
- [x] Both builds coexist — no cleaning needed between them
- [x] `make test` passes all tests
- [x] `make clean` removes `obj/` entirely