### PR TITLE
Add jk_botti_mm.so symlink to releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,10 @@ jobs:
         with:
           name: windows-binary
           path: addons/jk_botti/dlls
+      - name: Prepare release directory
+        run: |
+          rm -f addons/jk_botti/dlls/.empty_dir
+          ln -sf jk_botti_mm_i386.so addons/jk_botti/dlls/jk_botti_mm.so
       - name: Create release archive
         run: tar c addons | xz > jk_botti-snapshot-release.tar.xz
       - name: Upload release artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,10 @@ jobs:
         with:
           name: windows-binary
           path: addons/jk_botti/dlls
+      - name: Prepare release directory
+        run: |
+          rm -f addons/jk_botti/dlls/.empty_dir
+          ln -sf jk_botti_mm_i386.so addons/jk_botti/dlls/jk_botti_mm.so
       - name: Create release archive
         run: tar c addons | xz > jk_botti-${{ steps.get_version.outputs.VERSION }}-release.tar.xz
       - name: Create GitHub release

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ ZLIB_LIB = $(OBJDIR)/zlib/libz.a
 ${TARGET}${DLLEND}: $(ZLIB_LIB) ${OBJ}
 	${CC} -o $@ ${OBJ} $(ZLIB_LIB) ${LINKFLAGS}
 	cp $@ addons/jk_botti/dlls/
+ifneq ($(OSTYPE),win32)
+	ln -sf ${TARGET}${DLLEND} addons/jk_botti/dlls/${TARGET}.so
+endif
 
 $(ZLIB_LIB): | $(OBJDIR)/zlib
 	(cd $(OBJDIR)/zlib; AR="${AR}" ARFLAGS="" RANLIB="${RANLIB}" CC="${CC} ${OPTFLAGS} ${ARCHFLAG} ${ZLIB_OSFLAGS}" $(CURDIR)/zlib/configure --static; $(MAKE) libz.a CC="${CC} ${OPTFLAGS} ${ARCHFLAG} ${ZLIB_OSFLAGS}" AR="${AR}" ARFLAGS="" RANLIB="${RANLIB}")


### PR DESCRIPTION
## Summary
- Create `jk_botti_mm.so -> jk_botti_mm_i386.so` symlink in `addons/jk_botti/dlls/` during linux builds
- Add symlink creation step to CI and release workflows
- Remove `.empty_dir` from release archives

## Test plan
- [x] `make` creates symlink in `addons/jk_botti/dlls/`
- [x] CI snapshot archive contains symlink and no `.empty_dir`
- [ ] Release archive contains symlink and no `.empty_dir`