### PR TITLE
Fix BotCanJumpUp not setting bDuckJump for crouch-jump

### DIFF
--- a/bot_navigate.cpp
+++ b/bot_navigate.cpp
@@ -1799,6 +1799,9 @@ qboolean BotCanJumpUp( bot_t &pBot, qboolean *bDuckJump)
    if (tr.flFraction < 1.0f)
       return FALSE;
 
+   if (check_duck)
+      *bDuckJump = TRUE;
+
    return TRUE;
 }
 

--- a/tests/test_bot_navigate.cpp
+++ b/tests/test_bot_navigate.cpp
@@ -434,6 +434,7 @@ static int test_can_jump_up_blocked_normal_clear_duck(void)
    qboolean result = BotCanJumpUp(bot, &bDuckJump);
 
    ASSERT_INT(result, TRUE);
+   ASSERT_INT(bDuckJump, TRUE);
    PASS();
    return 0;
 }


### PR DESCRIPTION
## Summary

- **BotCanJumpUp** returned TRUE when the crouch-jump path succeeded but never set `*bDuckJump = TRUE`
- The caller in `bot.cpp:1977` checks `bCrouchJump` to decide whether to press `IN_DUCK` along with `IN_JUMP`
- Without the duck flag, the bot did a regular jump (too low) and stayed stuck on obstacles that required a crouch-jump

## Test plan

- [x] Existing test updated to assert `bDuckJump == TRUE` on duck path
- [x] Normal jump path still returns `bDuckJump == FALSE`
- [x] All 46 bot_navigate tests pass