### PR TITLE
Add tests for all remaining untested waypoint.cpp functions

### DIFF
--- a/tests/engine_mock.h
+++ b/tests/engine_mock.h
@@ -38,4 +38,8 @@ typedef void (*mock_trace_fn)(const float *v1, const float *v2,
 extern mock_trace_fn mock_trace_hull_fn;
 extern mock_trace_fn mock_trace_line_fn;
 
+// Control what POINT_CONTENTS returns
+typedef int (*mock_point_contents_fn_t)(const float *origin);
+extern mock_point_contents_fn_t mock_point_contents_fn;
+
 #endif // ENGINE_MOCK_H


### PR DESCRIPTION
## Summary
- Add 32 new tests covering 8 waypoint.cpp functions that had zero test coverage: `WaypointAddBlock`, `WaypointInBlockRadius`, `WaypointSlowFloydsStop`, `WaypointSlowFloydsState`, `WaypointDrawBeam`, `WaypointRouteInit`, `WaypointAutowaypointing`, and `WaypointThink`
- Waypoint test count goes from 139 to 171, achieving 100% compiled-function coverage for waypoint.cpp
- Tests organized into 6 groups: block list, slow floyds helpers, draw beam, route init (with file I/O), autowaypointing (early returns + all addition paths), and think dispatch

## Test plan
- [x] `make test` passes (171/171 waypoint tests, all other suites green)
- [x] `make valgrind` passes (0 errors, 0 leaks)
- [x] No new compiler warnings