### PR TITLE
Add gcov coverage collection for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,38 @@ jobs:
       - name: Run valgrind
         run: CXX="g++ -m32" make valgrind
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update package list for i386
+        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
+      - name: Install packages
+        run: sudo apt-get -y install build-essential g++-multilib lcov
+      - name: Run coverage
+        run: CXX="g++ -m32" make coverage
+      - name: Generate job summary
+        run: |
+          summary=$(lcov --summary tests/coverage.info --branch-coverage \
+              --ignore-errors inconsistent,deprecated 2>&1)
+          lines=$(echo "$summary" | sed -n 's/.*lines\.\+: \([0-9.]*\)% (\([0-9]*\) of \([0-9]*\).*/| Lines | \2 | \3 | \1% |/p')
+          funcs=$(echo "$summary" | sed -n 's/.*functions\.\+: \([0-9.]*\)% (\([0-9]*\) of \([0-9]*\).*/| Functions | \2 | \3 | \1% |/p')
+          branches=$(echo "$summary" | sed -n 's/.*branches\.\+: \([0-9.]*\)% (\([0-9]*\) of \([0-9]*\).*/| Branches | \2 | \3 | \1% |/p')
+          {
+            echo "### Coverage Summary"
+            echo ""
+            echo "| Metric | Hit | Total | Coverage |"
+            echo "|--------|-----|-------|----------|"
+            echo "$lines"
+            echo "$funcs"
+            echo "$branches"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: tests/coverage_report
+
   build-linux:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ tests/bench_*
 !tests/bench_*.cpp
 !tests/bench_*.h
 tmp/
+*.gcda
+*.gcno
+*.gcov
+coverage.info
+tests/coverage_report/

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ test: $(ZLIB_LIB)
 valgrind: $(ZLIB_LIB)
 	$(MAKE) -C tests CXXFLAGS="$(CXXFLAGS)" ZLIB_LIB="../$(ZLIB_LIB)" valgrind
 
+coverage: $(ZLIB_LIB)
+	$(MAKE) -C tests CXXFLAGS="$(CXXFLAGS)" ZLIB_LIB="../$(ZLIB_LIB)" coverage
+
 clean:
 	rm -rf obj ${TARGET}${DLLEND} Rules.depend
 	$(MAKE) -C tests clean

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,23 +1,25 @@
 # tests/Makefile
 
 ZLIB_LIB ?= ../zlib/libz.a
+COVERAGE_FLAGS ?=
+GCOV ?= $(subst g++,gcov,$(firstword $(CXX)))
 
 PARENT_INCLUDES = -I"../metamod" -I"../common" -I"../dlls" -I"../engine" -I"../pm_shared"
-TEST_CXXFLAGS = ${CXXFLAGS} ${PARENT_INCLUDES} -I".."
+TEST_CXXFLAGS = ${CXXFLAGS} ${PARENT_INCLUDES} -I".." $(COVERAGE_FLAGS)
 
 # Simple self-contained tests
 test_name_sanitize: test_name_sanitize.cpp ../bot_name_sanitize.h
-	${CXX} -Wall -o $@ $<
+	${CXX} -Wall $(COVERAGE_FLAGS) -o $@ $<
 
 test_posdata_list: test_posdata_list.cpp ../posdata_list.h
-	${CXX} -Wall -o $@ $<
+	${CXX} -Wall $(COVERAGE_FLAGS) -o $@ $<
 
 # Engine-mock based tests
 BOT_COMBAT_OBJS = engine_mock.o test_bot_combat.o \
 	bot_combat.o bot_weapons.o util.o safe_snprintf.o random_num.o
 
 test_bot_combat: $(BOT_COMBAT_OBJS)
-	${CXX} -o $@ $(BOT_COMBAT_OBJS) -lm
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_COMBAT_OBJS) -lm
 
 %.o: %.cpp
 	${CXX} ${TEST_CXXFLAGS} -c $< -o $@
@@ -29,68 +31,68 @@ test_bot_combat: $(BOT_COMBAT_OBJS)
 SAFE_SNPRINTF_OBJS = test_safe_snprintf.o safe_snprintf.o
 
 test_safe_snprintf: $(SAFE_SNPRINTF_OBJS)
-	${CXX} -o $@ $(SAFE_SNPRINTF_OBJS)
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(SAFE_SNPRINTF_OBJS)
 
 # Random number generator test
 RANDOM_NUM_OBJS = test_random_num.o random_num.o
 
 test_random_num: $(RANDOM_NUM_OBJS)
-	${CXX} -o $@ $(RANDOM_NUM_OBJS) -lm
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(RANDOM_NUM_OBJS) -lm
 
 # Util bug fix tests
 UTIL_TEST_OBJS = engine_mock.o test_util.o util.o safe_snprintf.o random_num.o
 
 test_util: $(UTIL_TEST_OBJS)
-	${CXX} -o $@ $(UTIL_TEST_OBJS) -lm
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(UTIL_TEST_OBJS) -lm
 
 # Bot chat tests (bot_chat.cpp is #included in test file, not linked separately)
 BOT_CHAT_OBJS = engine_mock.o test_bot_chat.o util.o safe_snprintf.o random_num.o
 
 test_bot_chat: $(BOT_CHAT_OBJS)
-	${CXX} -o $@ $(BOT_CHAT_OBJS) -lm
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_CHAT_OBJS) -lm
 
 # Neural net training test
 NEURALNET_OBJS = test_neuralnet.o neuralnet.o geneticalg.o random_num.o
 
 test_neuralnet: $(NEURALNET_OBJS)
-	${CXX} -o $@ $(NEURALNET_OBJS) -lm
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(NEURALNET_OBJS) -lm
 
 # Genetic algorithm unit tests (geneticalg.cpp is #included in test file)
 GENETICALG_OBJS = test_geneticalg.o random_num.o
 
 test_geneticalg: $(GENETICALG_OBJS)
-	${CXX} -o $@ $(GENETICALG_OBJS) -lm
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(GENETICALG_OBJS) -lm
 
 # Bot weapons tests
 BOT_WEAPONS_OBJS = engine_mock.o test_bot_weapons.o \
 	bot_weapons.o util.o safe_snprintf.o random_num.o
 
 test_bot_weapons: $(BOT_WEAPONS_OBJS)
-	${CXX} -o $@ $(BOT_WEAPONS_OBJS) -lm
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_WEAPONS_OBJS) -lm
 
 # Bot navigate tests
 BOT_NAVIGATE_OBJS = engine_mock.o test_bot_navigate.o \
 	bot_navigate.o bot_weapons.o util.o safe_snprintf.o random_num.o
 
 test_bot_navigate: $(BOT_NAVIGATE_OBJS)
-	${CXX} -o $@ $(BOT_NAVIGATE_OBJS) -lm
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_NAVIGATE_OBJS) -lm
 
 # Bot skill tests (bot_skill.cpp is #included in test file, not linked separately)
 test_bot_skill: test_bot_skill.o
-	${CXX} -o $@ test_bot_skill.o
+	${CXX} $(COVERAGE_FLAGS) -o $@ test_bot_skill.o
 
 # Bot sound tests
 BOT_SOUND_OBJS = engine_mock.o test_bot_sound.o \
 	bot_sound.o util.o safe_snprintf.o random_num.o
 
 test_bot_sound: $(BOT_SOUND_OBJS)
-	${CXX} -o $@ $(BOT_SOUND_OBJS) -lm
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_SOUND_OBJS) -lm
 
 # Waypoint tests (waypoint.cpp is #included in test file, not linked separately)
 WAYPOINT_OBJS = engine_mock.o test_waypoint.o bot_weapons.o util.o safe_snprintf.o random_num.o
 
 test_waypoint: $(WAYPOINT_OBJS) $(ZLIB_LIB)
-	${CXX} -o $@ $(WAYPOINT_OBJS) $(ZLIB_LIB) -lm
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(WAYPOINT_OBJS) $(ZLIB_LIB) -lm
 
 ALL_TESTS = test_name_sanitize test_posdata_list test_bot_combat test_bot_weapons test_util test_bot_chat test_safe_snprintf test_random_num test_neuralnet test_geneticalg test_waypoint test_bot_navigate test_bot_skill test_bot_sound
 
@@ -130,5 +132,28 @@ valgrind: $(ALL_TESTS)
 	$(VALGRIND) ./test_bot_skill
 	$(VALGRIND) ./test_bot_sound
 
+coverage:
+	$(MAKE) clean
+	rm -f *.gcda *.gcno coverage.info
+	rm -rf coverage_report
+	$(MAKE) COVERAGE_FLAGS="--coverage" run
+	lcov --capture --directory . --output-file coverage.info \
+	    --gcov-tool $(GCOV) --branch-coverage \
+	    --ignore-errors inconsistent,deprecated
+	lcov --remove coverage.info '*/tests/*' '*/zlib/*' '*/engine/*' \
+	    '*/metamod/*' '*/common/*' '*/dlls/*' '*/pm_shared/*' \
+	    '/usr/*' \
+	    --output-file coverage.info --branch-coverage \
+	    --ignore-errors inconsistent,deprecated,unused
+	genhtml coverage.info --output-directory coverage_report \
+	    --branch-coverage --ignore-errors inconsistent,deprecated
+	lcov --summary coverage.info --branch-coverage \
+	    --ignore-errors inconsistent,deprecated
+
+coverage-clean:
+	rm -f *.gcda *.gcno coverage.info
+	rm -rf coverage_report
+
 clean:
-	rm -f $(ALL_TESTS) *.o
+	rm -f $(ALL_TESTS) *.o *.gcda *.gcno *.gcov coverage.info
+	rm -rf coverage_report


### PR DESCRIPTION
## Summary

- Add `make coverage` target using `--coverage` (gcov) + lcov/genhtml for line/branch/function coverage reporting
- Add CI `coverage` job that runs coverage, uploads HTML report as artifact, and writes a summary table to GitHub Actions job summary
- Add `.gitignore` entries for gcov artifacts and coverage output

## Test plan

- [x] CI coverage job passes and produces summary table on Actions page
- [x] Coverage report artifact is downloadable and contains browsable HTML
- [x] `make coverage` works locally with cross-compiler
- [x] `make clean` removes gcov artifacts