### PR TITLE
Add placeholder tests for 10 previously untested source files

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -94,7 +94,77 @@ WAYPOINT_OBJS = engine_mock.o test_waypoint.o bot_weapons.o util.o safe_snprintf
 test_waypoint: $(WAYPOINT_OBJS) $(ZLIB_LIB)
 	${CXX} $(COVERAGE_FLAGS) -o $@ $(WAYPOINT_OBJS) $(ZLIB_LIB) -lm
 
-ALL_TESTS = test_name_sanitize test_posdata_list test_bot_combat test_bot_weapons test_util test_bot_chat test_safe_snprintf test_random_num test_neuralnet test_geneticalg test_waypoint test_bot_navigate test_bot_skill test_bot_sound
+# h_export tests (h_export.cpp is #included in test file, standalone)
+test_h_export: test_h_export.o
+	${CXX} $(COVERAGE_FLAGS) -o $@ test_h_export.o
+
+# bot_config_init tests
+BOT_CONFIG_INIT_OBJS = engine_mock.o test_bot_config_init.o \
+	bot_config_init.o util.o safe_snprintf.o random_num.o
+
+test_bot_config_init: $(BOT_CONFIG_INIT_OBJS)
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_CONFIG_INIT_OBJS) -lm
+
+# bot_models tests
+BOT_MODELS_OBJS = engine_mock.o test_bot_models.o \
+	bot_models.o util.o safe_snprintf.o random_num.o
+
+test_bot_models: $(BOT_MODELS_OBJS)
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_MODELS_OBJS) -lm
+
+# bot_client tests
+BOT_CLIENT_OBJS = engine_mock.o test_bot_client.o \
+	bot_client.o bot_weapons.o util.o safe_snprintf.o random_num.o
+
+test_bot_client: $(BOT_CLIENT_OBJS)
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_CLIENT_OBJS) -lm
+
+# bot tests
+BOT_OBJS = engine_mock.o test_bot.o \
+	bot.o bot_config_init.o bot_weapons.o util.o safe_snprintf.o random_num.o
+
+test_bot: $(BOT_OBJS)
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_OBJS) -lm
+
+# commands tests
+COMMANDS_OBJS = engine_mock.o test_commands.o \
+	commands.o bot_weapons.o util.o safe_snprintf.o random_num.o
+
+test_commands: $(COMMANDS_OBJS)
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(COMMANDS_OBJS) -lm
+
+# dll tests (dll.cpp needs VER_NOTE as a proper C string literal)
+dll.o: ../dll.cpp
+	${CXX} ${TEST_CXXFLAGS} -UVER_NOTE -DVER_NOTE='"test"' -c $< -o $@
+
+DLL_OBJS = engine_mock.o test_dll.o \
+	dll.o bot_weapons.o bot_sound.o util.o safe_snprintf.o random_num.o
+
+test_dll: $(DLL_OBJS)
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(DLL_OBJS) -lm
+
+# engine tests
+ENGINE_OBJS = engine_mock.o test_engine.o \
+	engine.o bot_weapons.o bot_sound.o util.o safe_snprintf.o random_num.o
+
+test_engine: $(ENGINE_OBJS)
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(ENGINE_OBJS) -lm
+
+# bot_query_hook tests
+BOT_QUERY_HOOK_OBJS = engine_mock.o test_bot_query_hook.o \
+	bot_query_hook.o util.o safe_snprintf.o random_num.o
+
+test_bot_query_hook: $(BOT_QUERY_HOOK_OBJS)
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_QUERY_HOOK_OBJS) -lm
+
+# bot_query_hook_linux tests
+BOT_QUERY_HOOK_LINUX_OBJS = engine_mock.o test_bot_query_hook_linux.o \
+	bot_query_hook_linux.o util.o safe_snprintf.o random_num.o
+
+test_bot_query_hook_linux: $(BOT_QUERY_HOOK_LINUX_OBJS)
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_QUERY_HOOK_LINUX_OBJS) -lm -lpthread
+
+ALL_TESTS = test_name_sanitize test_posdata_list test_bot_combat test_bot_weapons test_util test_bot_chat test_safe_snprintf test_random_num test_neuralnet test_geneticalg test_waypoint test_bot_navigate test_bot_skill test_bot_sound test_h_export test_bot_config_init test_bot_models test_bot_client test_bot test_commands test_dll test_engine test_bot_query_hook test_bot_query_hook_linux
 
 all: $(ALL_TESTS)
 
@@ -113,6 +183,16 @@ run: $(ALL_TESTS)
 	./test_bot_navigate
 	./test_bot_skill
 	./test_bot_sound
+	./test_h_export
+	./test_bot_config_init
+	./test_bot_models
+	./test_bot_client
+	./test_bot
+	./test_commands
+	./test_dll
+	./test_engine
+	./test_bot_query_hook
+	./test_bot_query_hook_linux
 
 VALGRIND = valgrind --leak-check=full --error-exitcode=1
 
@@ -131,6 +211,16 @@ valgrind: $(ALL_TESTS)
 	$(VALGRIND) ./test_bot_navigate
 	$(VALGRIND) ./test_bot_skill
 	$(VALGRIND) ./test_bot_sound
+	$(VALGRIND) ./test_h_export
+	$(VALGRIND) ./test_bot_config_init
+	$(VALGRIND) ./test_bot_models
+	$(VALGRIND) ./test_bot_client
+	$(VALGRIND) ./test_bot
+	$(VALGRIND) ./test_commands
+	$(VALGRIND) ./test_dll
+	$(VALGRIND) ./test_engine
+	$(VALGRIND) ./test_bot_query_hook
+	$(VALGRIND) ./test_bot_query_hook_linux
 
 coverage:
 	$(MAKE) clean

--- a/tests/engine_mock.cpp
+++ b/tests/engine_mock.cpp
@@ -79,36 +79,36 @@ enginefuncs_t g_engfuncs;
 
 // Metamod globals
 static meta_globals_t mock_metaglobals;
-meta_globals_t *gpMetaGlobals = &mock_metaglobals;
+__attribute__((weak)) meta_globals_t *gpMetaGlobals = &mock_metaglobals;
 
 static mutil_funcs_t mock_mutil_funcs;
-mutil_funcs_t *gpMetaUtilFuncs = &mock_mutil_funcs;
+__attribute__((weak)) mutil_funcs_t *gpMetaUtilFuncs = &mock_mutil_funcs;
 
 static DLL_FUNCTIONS mock_dll_functions;
 static gamedll_funcs_t mock_gamedll_funcs = { &mock_dll_functions, NULL };
-gamedll_funcs_t *gpGamedllFuncs = &mock_gamedll_funcs;
+__attribute__((weak)) gamedll_funcs_t *gpGamedllFuncs = &mock_gamedll_funcs;
 
-plugin_info_t Plugin_info;
+__attribute__((weak)) plugin_info_t Plugin_info;
 
 // ============================================================
 // Extern globals from production .cpp files
 // ============================================================
 
-bot_weapon_t weapon_defs[MAX_WEAPONS];
-bot_t bots[32];
-player_t players[32];
-qboolean b_observer_mode = FALSE;
-qboolean is_team_play = FALSE;
-qboolean checked_teamplay = FALSE;
-qboolean b_botdontshoot = FALSE;
-int num_logos = 0;
-int submod_id = SUBMOD_HLDM;
-int submod_weaponflag = WEAPON_SUBMOD_HLDM;
-int bot_shoot_breakables = 0;
-int m_spriteTexture = 0;
+__attribute__((weak)) bot_weapon_t weapon_defs[MAX_WEAPONS];
+__attribute__((weak)) bot_t bots[32];
+__attribute__((weak)) player_t players[32];
+__attribute__((weak)) qboolean b_observer_mode = FALSE;
+__attribute__((weak)) qboolean is_team_play = FALSE;
+__attribute__((weak)) qboolean checked_teamplay = FALSE;
+__attribute__((weak)) qboolean b_botdontshoot = FALSE;
+__attribute__((weak)) int num_logos = 0;
+__attribute__((weak)) int submod_id = SUBMOD_HLDM;
+__attribute__((weak)) int submod_weaponflag = WEAPON_SUBMOD_HLDM;
+__attribute__((weak)) int bot_shoot_breakables = 0;
+__attribute__((weak)) int m_spriteTexture = 0;
 __attribute__((weak)) int num_waypoints = 0;
 __attribute__((weak)) WAYPOINT waypoints[MAX_WAYPOINTS];
-bot_skill_settings_t skill_settings[5];
+__attribute__((weak)) bot_skill_settings_t skill_settings[5];
 __attribute__((weak)) CSoundEnt *pSoundEnt = NULL;
 
 // ============================================================
@@ -447,23 +447,23 @@ __attribute__((weak)) void SaveSound(edict_t *pEdict, const Vector &origin, int 
 { (void)pEdict; (void)origin; (void)volume; (void)channel; (void)flDuration; }
 
 // commands.cpp
-void FakeClientCommand(edict_t *pBot, const char *arg1, const char *arg2, const char *arg3)
+__attribute__((weak)) void FakeClientCommand(edict_t *pBot, const char *arg1, const char *arg2, const char *arg3)
 { (void)pBot; (void)arg1; (void)arg2; (void)arg3; }
-const cfg_bot_record_t *GetUnusedCfgBotRecord(void) { return NULL; }
+__attribute__((weak)) const cfg_bot_record_t *GetUnusedCfgBotRecord(void) { return NULL; }
 
 // dll.cpp
-void jkbotti_ClientPutInServer(edict_t *pEntity) { (void)pEntity; }
-BOOL jkbotti_ClientConnect(edict_t *pEntity, const char *pszName,
+__attribute__((weak)) void jkbotti_ClientPutInServer(edict_t *pEntity) { (void)pEntity; }
+__attribute__((weak)) BOOL jkbotti_ClientConnect(edict_t *pEntity, const char *pszName,
                            const char *pszAddress, char szRejectReason[128])
 { (void)pEntity; (void)pszName; (void)pszAddress; (void)szRejectReason; return TRUE; }
 
 // bot.cpp
-void BotCreate(const char *skin, const char *name, int skill, int top_color,
+__attribute__((weak)) void BotCreate(const char *skin, const char *name, int skill, int top_color,
                int bottom_color, int cfg_bot_index)
 { (void)skin; (void)name; (void)skill; (void)top_color; (void)bottom_color; (void)cfg_bot_index; }
-void BotThink(bot_t &pBot) { (void)pBot; }
-void BotCheckTeamplay(void) {}
-void BotKick(bot_t &pBot) { (void)pBot; }
+__attribute__((weak)) void BotThink(bot_t &pBot) { (void)pBot; }
+__attribute__((weak)) void BotCheckTeamplay(void) {}
+__attribute__((weak)) void BotKick(bot_t &pBot) { (void)pBot; }
 
 // bot_chat.cpp (weak: overridden by test_bot_chat.cpp which #includes bot_chat.cpp)
 __attribute__((weak)) void LoadBotChat(void) {}
@@ -473,13 +473,13 @@ __attribute__((weak)) void BotChatTalk(bot_t &pBot) { (void)pBot; }
 __attribute__((weak)) void BotChatEndGame(bot_t &pBot) { (void)pBot; }
 
 // bot_skill.cpp
-void ResetSkillsToDefault(void) {}
+__attribute__((weak)) void ResetSkillsToDefault(void) {}
 
 // bot_models.cpp
-void LoadBotModels(void) {}
+__attribute__((weak)) void LoadBotModels(void) {}
 
 // dlls/util.h (EMIT_SOUND_DYN not used by bot_combat.o/util.o but may be needed)
-void EMIT_SOUND_DYN(edict_t *entity, int channel, const char *sample,
+__attribute__((weak)) void EMIT_SOUND_DYN(edict_t *entity, int channel, const char *sample,
                     float volume, float attenuation, int flags, int pitch)
 { (void)entity; (void)channel; (void)sample; (void)volume;
   (void)attenuation; (void)flags; (void)pitch; }

--- a/tests/test_bot.cpp
+++ b/tests/test_bot.cpp
@@ -1,0 +1,188 @@
+//
+// JK_Botti - placeholder tests for bot.cpp
+//
+// test_bot.cpp
+//
+
+#include <stdlib.h>
+#include <math.h>
+
+#include <extdll.h>
+#include <dllapi.h>
+#include <h_export.h>
+#include <meta_api.h>
+
+#include "bot.h"
+#include "bot_func.h"
+#include "bot_weapons.h"
+#include "bot_skill.h"
+#include "bot_config_init.h"
+#include "bot_client.h"
+#include "waypoint.h"
+#include "player.h"
+
+#include "engine_mock.h"
+#include "test_common.h"
+
+// ============================================================
+// Stubs for symbols not in engine_mock or linked .o files
+// ============================================================
+
+// dll.cpp globals
+int default_bot_skill = 2;
+int bot_add_level_tag = 0;
+int bot_chat_percent = 10;
+int bot_taunt_percent = 20;
+int bot_whine_percent = 10;
+int bot_endgame_percent = 40;
+int bot_logo_percent = 40;
+int bot_chat_tag_percent = 80;
+int bot_chat_drop_percent = 10;
+int bot_chat_swap_percent = 10;
+int bot_chat_lower_percent = 50;
+qboolean b_random_color = TRUE;
+int debug_minmax = 0;
+int team_balancetype = 1;
+char *team_blockedlist = NULL;
+float bot_think_spf = 1.0f/30.0f;
+float bot_check_time = 60.0;
+int min_bots = -1;
+int max_bots = -1;
+int num_bots = 0;
+int prev_num_bots = 0;
+float welcome_time = 0.0;
+qboolean welcome_sent = FALSE;
+int bot_stop = 0;
+int frame_count = 0;
+int randomize_bots_on_mapchange = 0;
+float bot_cfg_pause_time = 0.0;
+FILE *bot_cfg_fp = NULL;
+int bot_cfg_linenumber = 0;
+qboolean need_to_open_cfg = TRUE;
+qboolean spawn_time_reset = FALSE;
+float waypoint_time = 0.0;
+
+// engine.cpp globals
+qboolean g_in_intermission = FALSE;
+char g_argv[1024*3];
+char g_arg1[1024];
+char g_arg2[1024];
+char g_arg3[1024];
+void (*botMsgFunction)(void *, int) = NULL;
+void (*botMsgEndFunction)(void *, int) = NULL;
+int botMsgIndex = 0;
+
+// bot_chat.cpp globals
+int bot_chat_count = 0;
+int bot_taunt_count = 0;
+int bot_whine_count = 0;
+int bot_endgame_count = 0;
+int recent_bot_chat[5] = {};
+int recent_bot_taunt[5] = {};
+int recent_bot_whine[5] = {};
+int recent_bot_endgame[5] = {};
+bot_chat_t bot_chat[MAX_BOT_CHAT];
+bot_chat_t bot_whine[MAX_BOT_CHAT];
+
+// bot_combat.cpp globals
+char g_team_list[TEAMPLAY_TEAMLISTLENGTH];
+char g_team_names[MAX_TEAMS][MAX_TEAMNAME_LENGTH];
+int g_team_scores[MAX_TEAMS];
+int g_num_teams = 0;
+qboolean g_team_limit = FALSE;
+
+// commands.cpp globals
+qboolean isFakeClientCommand = FALSE;
+int fake_arg_count = 0;
+int bot_conntimes = 0;
+
+// bot_combat.cpp functions
+void BotAimPre(bot_t &pBot) { (void)pBot; }
+void BotAimPost(bot_t &pBot) { (void)pBot; }
+void free_posdata_list(int idx) { (void)idx; }
+void GatherPlayerData(edict_t *pEdict) { (void)pEdict; }
+qboolean FPredictedVisible(bot_t &pBot) { (void)pBot; return FALSE; }
+void BotUpdateHearingSensitivity(bot_t &pBot) { (void)pBot; }
+void BotFindEnemy(bot_t &pBot) { (void)pBot; }
+void BotShootAtEnemy(bot_t &pBot) { (void)pBot; }
+qboolean BotShootTripmine(bot_t &pBot) { (void)pBot; return FALSE; }
+qboolean BotDetonateSatchel(bot_t &pBot) { (void)pBot; return FALSE; }
+
+// commands.cpp functions
+void ProcessBotCfgFile(void) {}
+void jk_botti_ServerCommand(void) {}
+void ClientCommand(edict_t *pEntity) { (void)pEntity; }
+int AddToCfgBotRecord(const char *skin, const char *name, int skill, int top_color, int bottom_color)
+{ (void)skin; (void)name; (void)skill; (void)top_color; (void)bottom_color; return 0; }
+void FreeCfgBotRecord(void) {}
+
+// bot_client.cpp functions
+void BotClient_Valve_WeaponList(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_CurrentWeapon(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_AmmoX(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_AmmoPickup(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_WeaponPickup(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_ItemPickup(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_Health(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_Battery(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_Damage(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_DeathMsg(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_ScreenFade(void *p, int bot_index) { (void)p; (void)bot_index; }
+
+// bot_navigate.cpp functions not already in engine_mock (weak stubs)
+void BotOnLadder(bot_t &pBot, float moved_distance) { (void)pBot; (void)moved_distance; }
+void BotUnderWater(bot_t &pBot) { (void)pBot; }
+void BotUseLift(bot_t &pBot, float moved_distance) { (void)pBot; (void)moved_distance; }
+void BotTurnAtWall(bot_t &pBot, TraceResult *tr, qboolean negative) { (void)pBot; (void)tr; (void)negative; }
+void BotRandomTurn(bot_t &pBot) { (void)pBot; }
+
+// waypoint.cpp functions
+void WaypointInit(void) {}
+int WaypointFindRunawayPath(int runner, int enemy) { (void)runner; (void)enemy; return -1; }
+float wp_display_time[MAX_WAYPOINTS];
+qboolean g_waypoint_on = FALSE;
+qboolean g_auto_waypoint = FALSE;
+qboolean g_path_waypoint = FALSE;
+qboolean g_path_waypoint_enable = FALSE;
+qboolean g_waypoint_updated = FALSE;
+BOOL wp_matrix_save_on_mapend = FALSE;
+
+// bot_models.cpp globals
+int number_skins = 0;
+skin_t bot_skins[MAX_SKINS];
+
+// bot_query_hook
+bool hook_sendto_function(void) { return true; }
+bool unhook_sendto_function(void) { return true; }
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_placeholder(void)
+{
+   TEST("bot.cpp placeholder");
+
+   mock_reset();
+
+   // Verify bots array defined by bot.o is accessible
+   ASSERT_TRUE(sizeof(bots) == sizeof(bot_t) * 32);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// main
+// ============================================================
+
+int main(void)
+{
+   int fail = 0;
+
+   printf("test_bot:\n");
+   fail |= test_placeholder();
+
+   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/test_bot_client.cpp
+++ b/tests/test_bot_client.cpp
@@ -1,0 +1,61 @@
+//
+// JK_Botti - placeholder tests for bot_client.cpp
+//
+// test_bot_client.cpp
+//
+
+#include <stdlib.h>
+#include <math.h>
+
+#include <extdll.h>
+#include <dllapi.h>
+#include <h_export.h>
+#include <meta_api.h>
+
+#include "bot.h"
+#include "bot_client.h"
+#include "bot_weapons.h"
+
+#include "engine_mock.h"
+#include "test_common.h"
+
+// Stubs for symbols not in engine_mock
+int bot_taunt_count = 0;
+int recent_bot_taunt[5] = {};
+bot_chat_t bot_taunt[MAX_BOT_CHAT];
+
+qboolean FPredictedVisible(bot_t &pBot) { (void)pBot; return FALSE; }
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_placeholder(void)
+{
+   TEST("bot_client.cpp placeholder");
+
+   mock_reset();
+   InitWeaponSelect(SUBMOD_HLDM);
+
+   // Verify weapon_defs array exists (defined by bot_client.o)
+   extern bot_weapon_t weapon_defs[MAX_WEAPONS];
+   ASSERT_TRUE(sizeof(weapon_defs) > 0);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// main
+// ============================================================
+
+int main(void)
+{
+   int fail = 0;
+
+   printf("test_bot_client:\n");
+   fail |= test_placeholder();
+
+   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/test_bot_combat.cpp
+++ b/tests/test_bot_combat.cpp
@@ -2370,7 +2370,7 @@ static int test_bot_should_detonate_satchel(void)
    pSatchel->v.owner = pBotEdict;
    pSatchel->v.origin = Vector(300, 0, 0);
 
-   edict_t *pEnemy = create_enemy_player(Vector(350, 0, 0));
+   (void)create_enemy_player(Vector(350, 0, 0));
    testbot.f_satchel_detonate_time = 10.0;
    ASSERT_INT(BotShouldDetonateSatchel(testbot), TRUE);
    PASS();
@@ -2393,7 +2393,7 @@ static int test_bot_should_detonate_satchel(void)
    pSatchel->v.owner = otherBot; // owned by someone else
    pSatchel->v.origin = Vector(300, 0, 0);
 
-   pEnemy = create_enemy_player(Vector(350, 0, 0));
+   (void)create_enemy_player(Vector(350, 0, 0));
    testbot.f_satchel_detonate_time = 10.0;
    testbot.b_satchel_detonating = TRUE;
    ASSERT_INT(BotShouldDetonateSatchel(testbot), FALSE);
@@ -2455,7 +2455,7 @@ static int test_bot_detonate_satchel(void)
    pSatchel->v.owner = pBotEdict;
    pSatchel->v.origin = Vector(300, 0, 0);
 
-   edict_t *pEnemy = create_enemy_player(Vector(350, 0, 0));
+   (void)create_enemy_player(Vector(350, 0, 0));
 
    testbot.f_satchel_detonate_time = gpGlobals->time - 1.0; // timeout reached
    testbot.f_satchel_check_time = 0;
@@ -2479,7 +2479,7 @@ static int test_bot_detonate_satchel(void)
    pSatchel->v.owner = pBotEdict;
    pSatchel->v.origin = Vector(300, 0, 0);
 
-   pEnemy = create_enemy_player(Vector(350, 0, 0));
+   (void)create_enemy_player(Vector(350, 0, 0));
 
    testbot.f_satchel_detonate_time = gpGlobals->time - 1.0;
    testbot.f_satchel_check_time = 0;
@@ -2505,7 +2505,7 @@ static int test_bot_detonate_satchel(void)
    pSatchel->v.owner = pBotEdict;
    pSatchel->v.origin = Vector(50, 0, 0); // too close to bot (< 200)
 
-   pEnemy = create_enemy_player(Vector(350, 0, 0));
+   (void)create_enemy_player(Vector(350, 0, 0));
 
    testbot.f_satchel_detonate_time = gpGlobals->time - 1.0; // timeout
    testbot.f_satchel_check_time = 0;
@@ -2559,7 +2559,7 @@ static int test_bot_shoot_tripmine(void)
    give_bot_weapon(testbot, VALVE_WEAPON_GLOCK, 17, 50, 0);
    // Need weapon_select initialized
    // BotFireWeapon needs the glock entry
-   qboolean result = BotShootTripmine(testbot);
+   BotShootTripmine(testbot);
    // Result depends on whether glock is available in weapon_select
    // In any case, pBotEnemy should be NULL after (restored)
    ASSERT_PTR_NULL(testbot.pBotEnemy);
@@ -3096,7 +3096,7 @@ static int test_bot_fire_weapon_min_skill_both(void)
       weapon_select[glock_idx].primary_skill_level = 1;
       weapon_select[glock_idx].secondary_skill_level = 2;
 
-      qboolean res = BotFireWeapon(Vector(200, 0, 0), testbot, 0);
+      BotFireWeapon(Vector(200, 0, 0), testbot, 0);
       // Should fall through to min-skill fallback
 
       // Restore
@@ -3239,7 +3239,6 @@ static int test_bot_fire_weapon_underwater(void)
          pBotEdict->v.weapons = (1u << weapon_select[idx].iId);
          testbot.f_primary_charging = -1;
          testbot.f_secondary_charging = -1;
-         int saved_idx = testbot.current_weapon_index;
          // Should NOT reset current_weapon_index since weapon is underwater-capable
          BotFireWeapon(Vector(200, 0, 0), testbot, 0);
          // Note: current_weapon_index might change due to reuse/selection logic,
@@ -3449,7 +3448,6 @@ static int test_bot_shoot_at_enemy_not_visible_reset(void)
    mock_trace_line_fn = AlternatingTrace::trace;
    mock_trace_hull_fn = trace_nohit;
 
-   float old_reaction = testbot.f_reaction_target_time;
    BotShootAtEnemy(testbot);
    // Should have hit the "not visible during fire" path (line 1867)
    // which calls BotResetReactionTime

--- a/tests/test_bot_config_init.cpp
+++ b/tests/test_bot_config_init.cpp
@@ -1,0 +1,52 @@
+//
+// JK_Botti - placeholder tests for bot_config_init.cpp
+//
+// test_bot_config_init.cpp
+//
+
+#include <stdlib.h>
+#include <math.h>
+
+#include <extdll.h>
+#include <dllapi.h>
+#include <h_export.h>
+#include <meta_api.h>
+
+#include "bot.h"
+#include "bot_config_init.h"
+
+#include "engine_mock.h"
+#include "test_common.h"
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_placeholder(void)
+{
+   TEST("bot_config_init.cpp placeholder");
+
+   mock_reset();
+
+   // Verify initial state of globals defined by bot_config_init.cpp
+   ASSERT_INT(number_names, 0);
+   ASSERT_INT(num_logos, 0);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// main
+// ============================================================
+
+int main(void)
+{
+   int fail = 0;
+
+   printf("test_bot_config_init:\n");
+   fail |= test_placeholder();
+
+   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/test_bot_models.cpp
+++ b/tests/test_bot_models.cpp
@@ -1,0 +1,54 @@
+//
+// JK_Botti - placeholder tests for bot_models.cpp
+//
+// test_bot_models.cpp
+//
+
+#include <stdlib.h>
+#include <math.h>
+
+#include <extdll.h>
+#include <dllapi.h>
+#include <h_export.h>
+#include <meta_api.h>
+
+#include "bot.h"
+
+#include "engine_mock.h"
+#include "test_common.h"
+
+// bot_models.cpp globals
+extern int number_skins;
+extern skin_t bot_skins[MAX_SKINS];
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_placeholder(void)
+{
+   TEST("bot_models.cpp placeholder");
+
+   mock_reset();
+
+   // LoadBotModels touches the filesystem, so just verify linkage
+   ASSERT_TRUE(sizeof(bot_skins) > 0);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// main
+// ============================================================
+
+int main(void)
+{
+   int fail = 0;
+
+   printf("test_bot_models:\n");
+   fail |= test_placeholder();
+
+   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/test_bot_query_hook.cpp
+++ b/tests/test_bot_query_hook.cpp
@@ -1,0 +1,75 @@
+//
+// JK_Botti - placeholder tests for bot_query_hook.cpp
+//
+// test_bot_query_hook.cpp
+//
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <extdll.h>
+#include <dllapi.h>
+#include <h_export.h>
+#include <meta_api.h>
+
+#include "bot.h"
+#include "bot_query_hook.h"
+
+#include "engine_mock.h"
+#include "test_common.h"
+
+// ============================================================
+// Stubs for symbols not in engine_mock
+// ============================================================
+
+int bot_conntimes = 0;
+
+void BotReplaceConnectionTime(const char *name, float *timeslot)
+{ (void)name; (void)timeslot; }
+
+ssize_t call_original_sendto(int socket, const void *message, size_t length, int flags,
+                             const struct sockaddr *dest_addr, socklen_t dest_len)
+{
+   (void)socket; (void)message; (void)length; (void)flags;
+   (void)dest_addr; (void)dest_len;
+   return (ssize_t)length;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_placeholder(void)
+{
+   TEST("bot_query_hook.cpp placeholder");
+
+   mock_reset();
+
+   // Verify sendto_hook function exists
+   extern ssize_t sendto_hook(int, const void *, size_t, int,
+                              const struct sockaddr *, socklen_t);
+
+   // With bot_conntimes=0, sendto_hook should call through to call_original_sendto
+   bot_conntimes = 0;
+   unsigned char buf[] = { 0xff, 0xff, 0xff, 0xff, 'D', 0x00 };
+   ssize_t ret = sendto_hook(0, buf, sizeof(buf), 0, NULL, 0);
+   ASSERT_INT((int)ret, (int)sizeof(buf));
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// main
+// ============================================================
+
+int main(void)
+{
+   int fail = 0;
+
+   printf("test_bot_query_hook:\n");
+   fail |= test_placeholder();
+
+   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/test_bot_query_hook_linux.cpp
+++ b/tests/test_bot_query_hook_linux.cpp
@@ -1,0 +1,74 @@
+//
+// JK_Botti - placeholder tests for bot_query_hook_linux.cpp
+//
+// test_bot_query_hook_linux.cpp
+//
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <extdll.h>
+#include <dllapi.h>
+#include <h_export.h>
+#include <meta_api.h>
+
+#include "bot.h"
+#include "bot_query_hook.h"
+
+#include "engine_mock.h"
+#include "test_common.h"
+
+// ============================================================
+// Stubs for symbols not in engine_mock
+// ============================================================
+
+int bot_conntimes = 0;
+
+void BotReplaceConnectionTime(const char *name, float *timeslot)
+{ (void)name; (void)timeslot; }
+
+// sendto_hook is defined in bot_query_hook.o
+ssize_t sendto_hook(int socket, const void *message, size_t length, int flags,
+                    const struct sockaddr *dest_addr, socklen_t dest_len)
+{
+   (void)socket; (void)message; (void)length; (void)flags;
+   (void)dest_addr; (void)dest_len;
+   return (ssize_t)length;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_placeholder(void)
+{
+   TEST("bot_query_hook_linux.cpp placeholder");
+
+   mock_reset();
+
+   // Verify hook/unhook functions exist and are callable
+   // Note: actually hooking sendto would modify libc, so just verify linkage
+   extern bool hook_sendto_function(void);
+   extern bool unhook_sendto_function(void);
+
+   // unhook should succeed when not hooked
+   ASSERT_TRUE(unhook_sendto_function() == true);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// main
+// ============================================================
+
+int main(void)
+{
+   int fail = 0;
+
+   printf("test_bot_query_hook_linux:\n");
+   fail |= test_placeholder();
+
+   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/test_commands.cpp
+++ b/tests/test_commands.cpp
@@ -1,0 +1,117 @@
+//
+// JK_Botti - placeholder tests for commands.cpp
+//
+// test_commands.cpp
+//
+
+#include <stdlib.h>
+#include <math.h>
+
+#include <extdll.h>
+#include <dllapi.h>
+#include <h_export.h>
+#include <meta_api.h>
+
+#include "bot.h"
+#include "bot_func.h"
+#include "bot_weapons.h"
+#include "bot_skill.h"
+#include "waypoint.h"
+#include "bot_query_hook.h"
+
+#include "engine_mock.h"
+#include "test_common.h"
+
+// ============================================================
+// Stubs for symbols not in engine_mock or linked .o files
+// ============================================================
+
+// dll.cpp globals
+int default_bot_skill = 2;
+int bot_add_level_tag = 0;
+int bot_chat_percent = 10;
+int bot_taunt_percent = 20;
+int bot_whine_percent = 10;
+int bot_endgame_percent = 40;
+int bot_logo_percent = 40;
+int bot_chat_tag_percent = 80;
+int bot_chat_drop_percent = 10;
+int bot_chat_swap_percent = 10;
+int bot_chat_lower_percent = 50;
+qboolean b_random_color = TRUE;
+int debug_minmax = 0;
+float bot_think_spf = 1.0f/30.0f;
+float bot_check_time = 60.0;
+int min_bots = -1;
+int max_bots = -1;
+int randomize_bots_on_mapchange = 0;
+FILE *bot_cfg_fp = NULL;
+int bot_cfg_linenumber = 0;
+int team_balancetype = 1;
+char *team_blockedlist = NULL;
+float bot_cfg_pause_time = 0.0;
+
+// engine.cpp globals
+qboolean g_in_intermission = FALSE;
+char g_argv[1024*3];
+char g_arg1[1024];
+char g_arg2[1024];
+char g_arg3[1024];
+
+// waypoint globals
+qboolean g_waypoint_on = FALSE;
+qboolean g_auto_waypoint = FALSE;
+qboolean g_path_waypoint = FALSE;
+qboolean g_path_waypoint_enable = FALSE;
+qboolean g_waypoint_updated = FALSE;
+float wp_display_time[MAX_WAYPOINTS];
+BOOL wp_matrix_save_on_mapend = FALSE;
+
+// bot_query_hook
+bool hook_sendto_function(void) { return true; }
+bool unhook_sendto_function(void) { return true; }
+
+// waypoint.cpp functions
+void WaypointAdd(edict_t *pEntity, int flags) { (void)pEntity; (void)flags; }
+void WaypointDelete(edict_t *pEntity) { (void)pEntity; }
+void WaypointCreatePath(edict_t *pEntity, int cmd) { (void)pEntity; (void)cmd; }
+void WaypointRemovePath(edict_t *pEntity, int cmd) { (void)pEntity; (void)cmd; }
+qboolean WaypointLoad(edict_t *pEntity) { (void)pEntity; return FALSE; }
+void WaypointSave(void) {}
+void WaypointPrintInfo(edict_t *pEntity) { (void)pEntity; }
+void WaypointUpdate(edict_t *pEntity) { (void)pEntity; }
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_placeholder(void)
+{
+   TEST("commands.cpp placeholder");
+
+   mock_reset();
+
+   // Verify commands.o globals are accessible
+   extern qboolean isFakeClientCommand;
+   extern int bot_conntimes;
+   ASSERT_INT(isFakeClientCommand, FALSE);
+   ASSERT_INT(bot_conntimes, 0);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// main
+// ============================================================
+
+int main(void)
+{
+   int fail = 0;
+
+   printf("test_commands:\n");
+   fail |= test_placeholder();
+
+   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/test_dll.cpp
+++ b/tests/test_dll.cpp
@@ -1,0 +1,162 @@
+//
+// JK_Botti - placeholder tests for dll.cpp
+//
+// test_dll.cpp
+//
+
+#include <stdlib.h>
+#include <math.h>
+
+#include <extdll.h>
+#include <dllapi.h>
+#include <h_export.h>
+#include <meta_api.h>
+
+#include "bot.h"
+#include "bot_func.h"
+#include "bot_weapons.h"
+#include "bot_skill.h"
+#include "bot_sound.h"
+#include "bot_config_init.h"
+#include "bot_client.h"
+#include "waypoint.h"
+#include "player.h"
+#include "bot_query_hook.h"
+
+#include "engine_mock.h"
+#include "test_common.h"
+
+// ============================================================
+// Stubs for symbols not in engine_mock or linked .o files
+// ============================================================
+
+// engine.cpp globals
+qboolean g_in_intermission = FALSE;
+char g_argv[1024*3];
+char g_arg1[1024];
+char g_arg2[1024];
+char g_arg3[1024];
+void (*botMsgFunction)(void *, int) = NULL;
+void (*botMsgEndFunction)(void *, int) = NULL;
+int botMsgIndex = 0;
+
+// bot_chat.cpp globals
+int bot_chat_count = 0;
+int bot_taunt_count = 0;
+int bot_whine_count = 0;
+int bot_endgame_count = 0;
+int recent_bot_chat[5] = {};
+int recent_bot_taunt[5] = {};
+int recent_bot_whine[5] = {};
+int recent_bot_endgame[5] = {};
+bot_chat_t bot_chat[MAX_BOT_CHAT];
+bot_chat_t bot_whine[MAX_BOT_CHAT];
+
+// bot_combat.cpp globals
+char g_team_list[TEAMPLAY_TEAMLISTLENGTH];
+char g_team_names[MAX_TEAMS][MAX_TEAMNAME_LENGTH];
+int g_team_scores[MAX_TEAMS];
+int g_num_teams = 0;
+qboolean g_team_limit = FALSE;
+
+// commands.cpp globals
+qboolean isFakeClientCommand = FALSE;
+int fake_arg_count = 0;
+int bot_conntimes = 0;
+
+// waypoint globals
+qboolean g_waypoint_on = FALSE;
+qboolean g_auto_waypoint = FALSE;
+qboolean g_path_waypoint = FALSE;
+qboolean g_path_waypoint_enable = FALSE;
+qboolean g_waypoint_updated = FALSE;
+float wp_display_time[MAX_WAYPOINTS];
+BOOL wp_matrix_save_on_mapend = FALSE;
+
+// bot_query_hook
+bool unhook_sendto_function(void) { return true; }
+
+// bot_config_init.cpp functions
+void BotNameInit(void) {}
+void BotLogoInit(void) {}
+
+// bot.cpp functions
+char * GetSpecificTeam(char *teamstr, size_t slen, qboolean get_smallest, qboolean get_largest, qboolean only_count_bots)
+{ (void)teamstr; (void)slen; (void)get_smallest; (void)get_largest; (void)only_count_bots; return NULL; }
+
+// waypoint.cpp functions (additional)
+void CollectMapSpawnItems(edict_t *pSpawn) { (void)pSpawn; }
+
+// bot_combat.cpp functions
+void free_posdata_list(int idx) { (void)idx; }
+void GatherPlayerData(edict_t *pEdict) { (void)pEdict; }
+
+// commands.cpp functions
+void ProcessBotCfgFile(void) {}
+void jk_botti_ServerCommand(void) {}
+void ClientCommand(edict_t *pEntity) { (void)pEntity; }
+int AddToCfgBotRecord(const char *skin, const char *name, int skill, int top_color, int bottom_color)
+{ (void)skin; (void)name; (void)skill; (void)top_color; (void)bottom_color; return 0; }
+void FreeCfgBotRecord(void) {}
+
+// bot_client.cpp functions
+void BotClient_Valve_WeaponList(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_CurrentWeapon(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_AmmoX(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_AmmoPickup(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_WeaponPickup(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_ItemPickup(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_Health(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_Battery(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_Damage(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_DeathMsg(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_ScreenFade(void *p, int bot_index) { (void)p; (void)bot_index; }
+
+// waypoint.cpp functions
+void WaypointInit(void) {}
+void WaypointAddSpawnObjects(void) {}
+void WaypointAddLift(edict_t *pent, const Vector &start, const Vector &end) { (void)pent; (void)start; (void)end; }
+qboolean WaypointLoad(edict_t *pEntity) { (void)pEntity; return FALSE; }
+void WaypointSave(void) {}
+void WaypointSaveFloydsMatrix(void) {}
+int WaypointSlowFloyds(void) { return 0; }
+int WaypointSlowFloydsState(void) { return 0; }
+void WaypointThink(edict_t *pEntity) { (void)pEntity; }
+
+// engine.cpp functions (need extern "C" to match C_DLLEXPORT declarations in dll.cpp)
+extern "C" int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion)
+{ (void)pengfuncsFromEngine; (void)interfaceVersion; return TRUE; }
+extern "C" int GetEngineFunctions_POST(enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion)
+{ (void)pengfuncsFromEngine; (void)interfaceVersion; return TRUE; }
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_placeholder(void)
+{
+   TEST("dll.cpp placeholder");
+
+   mock_reset();
+
+   // Verify dll.o globals are accessible
+   ASSERT_INT(submod_id, SUBMOD_HLDM);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// main
+// ============================================================
+
+int main(void)
+{
+   int fail = 0;
+
+   printf("test_dll:\n");
+   fail |= test_placeholder();
+
+   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/test_engine.cpp
+++ b/tests/test_engine.cpp
@@ -1,0 +1,85 @@
+//
+// JK_Botti - placeholder tests for engine.cpp
+//
+// test_engine.cpp
+//
+
+#include <stdlib.h>
+#include <math.h>
+
+#include <extdll.h>
+#include <dllapi.h>
+#include <h_export.h>
+#include <meta_api.h>
+
+#include "bot.h"
+#include "bot_client.h"
+#include "bot_func.h"
+#include "bot_sound.h"
+#include "bot_weapons.h"
+
+#include "engine_mock.h"
+#include "test_common.h"
+
+// ============================================================
+// Stubs for symbols not in engine_mock or linked .o files
+// ============================================================
+
+// commands.cpp globals
+qboolean isFakeClientCommand = FALSE;
+int fake_arg_count = 0;
+
+// engine.cpp declares these externs but may not use them all
+int get_cvars = 0;
+qboolean aim_fix = FALSE;
+float turn_skill = 3.0;
+
+// bot_client.cpp functions
+void BotClient_Valve_WeaponList(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_CurrentWeapon(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_AmmoX(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_AmmoPickup(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_WeaponPickup(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_ItemPickup(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_Health(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_Battery(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_Damage(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_DeathMsg(void *p, int bot_index) { (void)p; (void)bot_index; }
+void BotClient_Valve_ScreenFade(void *p, int bot_index) { (void)p; (void)bot_index; }
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_placeholder(void)
+{
+   TEST("engine.cpp placeholder");
+
+   mock_reset();
+
+   // Verify engine.o exported function exists
+   enginefuncs_t eng;
+   int version = 0;
+   memset(&eng, 0, sizeof(eng));
+   extern int GetEngineFunctions(enginefuncs_t *, int *);
+   int ret = GetEngineFunctions(&eng, &version);
+   ASSERT_INT(ret, TRUE);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// main
+// ============================================================
+
+int main(void)
+{
+   int fail = 0;
+
+   printf("test_engine:\n");
+   fail |= test_placeholder();
+
+   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/test_h_export.cpp
+++ b/tests/test_h_export.cpp
@@ -1,0 +1,59 @@
+//
+// JK_Botti - placeholder tests for h_export.cpp
+//
+// test_h_export.cpp
+//
+// Uses the #include-the-.cpp approach (h_export.cpp is self-contained).
+//
+
+#include <stdlib.h>
+#include <string.h>
+
+// Include the source file under test
+#include "../h_export.cpp"
+
+#include "test_common.h"
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_GiveFnptrsToDll_copies_engfuncs(void)
+{
+   TEST("GiveFnptrsToDll copies engine funcs and sets gpGlobals");
+
+   enginefuncs_t mock_eng;
+   globalvars_t mock_globals;
+   memset(&mock_eng, 0, sizeof(mock_eng));
+   memset(&mock_globals, 0, sizeof(mock_globals));
+   memset(&g_engfuncs, 0, sizeof(g_engfuncs));
+   gpGlobals = NULL;
+
+   // Set a recognizable value
+   mock_eng.pfnPrecacheModel = (int (*)(char *))0x12345678;
+   mock_globals.maxClients = 16;
+
+   GiveFnptrsToDll(&mock_eng, &mock_globals);
+
+   ASSERT_TRUE(g_engfuncs.pfnPrecacheModel == mock_eng.pfnPrecacheModel);
+   ASSERT_TRUE(gpGlobals == &mock_globals);
+   ASSERT_INT(gpGlobals->maxClients, 16);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// main
+// ============================================================
+
+int main(void)
+{
+   int fail = 0;
+
+   printf("test_h_export:\n");
+   fail |= test_GiveFnptrsToDll_copies_engfuncs();
+
+   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- Create minimal placeholder test files for h_export.cpp, bot_config_init.cpp, bot_models.cpp, bot_client.cpp, bot.cpp, commands.cpp, dll.cpp, engine.cpp, bot_query_hook.cpp, and bot_query_hook_linux.cpp so they appear in coverage reports
- Make engine_mock globals and function stubs `__attribute__((weak))` so production .o files can override them when linked into tests
- Fix pre-existing unused variable warnings in test_bot_combat.cpp

## Test plan
- [x] All 24 tests build and pass with `make test`
- [x] Zero compiler warnings (excluding SDK header noise)