### PR TITLE
Add HL:Arena weapon support

### DIFF
--- a/bot.h
+++ b/bot.h
@@ -35,6 +35,7 @@ typedef int BOOL;
 #define SUBMOD_BUBBLEMOD 2
 #define SUBMOD_XDM 3
 #define SUBMOD_OP4 4
+#define SUBMOD_ARENA 5
 
 
 // global defines

--- a/bot_weapons.cpp
+++ b/bot_weapons.cpp
@@ -103,25 +103,25 @@ bot_weapon_select_t valve_weapon_select[NUM_OF_WEAPON_SELECTS] =
     20, TRUE, 70, 1, 1, TRUE, TRUE, FALSE, FALSE, 0.0, 0.0, TRUE, 30, -1,
     W_IFL_GLOCK, W_IFL_AMMO_9MM, 0, TRUE, FALSE },
 
-   {GEARBOX_WEAPON_EAGLE, WEAPON_SUBMOD_OP4, "weapon_eagle", WEAPON_FIRE, 1.0,
+   {GEARBOX_WEAPON_EAGLE, WEAPON_SUBMOD_OP4 | WEAPON_SUBMOD_ARENA, "weapon_eagle", WEAPON_FIRE, 1.0,
     SKILL5, NOSKILL, FALSE, FALSE,
     32.0, 1400.0, 0, 0, 200.0,
     30, TRUE, 100, 1, 0, TRUE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, 12, -1,
     W_IFL_EAGLE, W_IFL_AMMO_357, 0, TRUE, FALSE },
 
-   {GEARBOX_WEAPON_PIPEWRENCH, WEAPON_SUBMOD_OP4, "weapon_pipewrench", WEAPON_MELEE, 1.0,
+   {GEARBOX_WEAPON_PIPEWRENCH, WEAPON_SUBMOD_OP4 | WEAPON_SUBMOD_ARENA, "weapon_pipewrench", WEAPON_MELEE, 1.0,
     SKILL4, NOSKILL, FALSE, FALSE,
     0.0, 40.0, 0, 0, 1.0,
     20, TRUE, 100, 0, 0, TRUE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, -1, -1,
     W_IFL_PIPEWRENCH, 0, 0, FALSE, FALSE },
 
-   {GEARBOX_WEAPON_M249, WEAPON_SUBMOD_OP4, "weapon_m249", WEAPON_FIRE, 1.0,
+   {GEARBOX_WEAPON_M249, WEAPON_SUBMOD_OP4 | WEAPON_SUBMOD_ARENA, "weapon_m249", WEAPON_FIRE, 1.0,
     SKILL3, NOSKILL, FALSE, FALSE,
     32.0, 1300.0, 0, 0, 200.0,
     60, FALSE, 100, 1, 0, TRUE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, 75, -1,
     W_IFL_M249, W_IFL_AMMO_556, 0, TRUE, FALSE },
 
-   {GEARBOX_WEAPON_DISPLACER, WEAPON_SUBMOD_OP4, "weapon_displacer", WEAPON_FIRE_AT_FEET, 1.0,
+   {GEARBOX_WEAPON_DISPLACER, WEAPON_SUBMOD_OP4 | WEAPON_SUBMOD_ARENA, "weapon_displacer", WEAPON_FIRE_AT_FEET, 1.0,
     SKILL2, NOSKILL, FALSE, FALSE,
     400.0, 1200.0, 0.0, 0.0, 450.0,
     30, FALSE, 100, 100, 0, FALSE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, 100, -1,
@@ -133,19 +133,19 @@ bot_weapon_select_t valve_weapon_select[NUM_OF_WEAPON_SELECTS] =
     15, FALSE, 100, 3, 0, TRUE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, -1, -1,
     W_IFL_SHOCKRIFLE, 0, 0, FALSE, FALSE },
 
-   {GEARBOX_WEAPON_SPORELAUNCHER, WEAPON_SUBMOD_OP4, "weapon_sporelauncher", WEAPON_FIRE_AT_FEET, 1.0,
+   {GEARBOX_WEAPON_SPORELAUNCHER, WEAPON_SUBMOD_OP4 | WEAPON_SUBMOD_ARENA, "weapon_sporelauncher", WEAPON_FIRE_AT_FEET, 1.0,
     SKILL3, NOSKILL, FALSE, FALSE,
     200.0, 1200.0, 0.0, 0.0, 250.0,
     60, TRUE, 100, 1, 0, TRUE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, 7, -1,
     W_IFL_SPORELAUNCHER, W_IFL_AMMO_SPORE, 0, TRUE, FALSE },
 
-   {GEARBOX_WEAPON_SNIPERRIFLE, WEAPON_SUBMOD_OP4, "weapon_sniperrifle", WEAPON_FIRE_ZOOM, 1.0,
+   {GEARBOX_WEAPON_SNIPERRIFLE, WEAPON_SUBMOD_OP4 | WEAPON_SUBMOD_ARENA, "weapon_sniperrifle", WEAPON_FIRE_ZOOM, 1.0,
     SKILL3, NOSKILL, FALSE, FALSE,
     32.0, 4000.0, 0, 0, 400.0,
     55, FALSE, 100, 1, 0, FALSE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, 5, -1,
     W_IFL_SNIPERRIFLE, W_IFL_AMMO_762, 0, TRUE, FALSE },
 
-   {GEARBOX_WEAPON_KNIFE, WEAPON_SUBMOD_OP4, "weapon_knife", WEAPON_MELEE, 1.0,
+   {GEARBOX_WEAPON_KNIFE, WEAPON_SUBMOD_OP4 | WEAPON_SUBMOD_ARENA, "weapon_knife", WEAPON_MELEE, 1.0,
     SKILL4, NOSKILL, FALSE, FALSE,
     0.0, 40.0, 0, 0, 1.0,
     20, TRUE, 100, 0, 0, TRUE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, -1, -1,
@@ -156,6 +156,24 @@ bot_weapon_select_t valve_weapon_select[NUM_OF_WEAPON_SELECTS] =
     0.0, 200.0, 0, 0, 100.0,
     5, TRUE, 100, 0, 0, TRUE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, -1, -1,
     W_IFL_GRAPPLE, 0, 0, FALSE, FALSE },
+
+   {ARENA_WEAPON_9MMSILENCED, WEAPON_SUBMOD_ARENA, "weapon_9mmsilenced", WEAPON_FIRE, 1.0,
+    SKILL5, NOSKILL, FALSE, FALSE,
+    32.0, 1400.0, 0, 0, 200.0,
+    25, TRUE, 100, 1, 0, TRUE, FALSE, FALSE, FALSE, 0.0, 0.0, TRUE, -1, -1,
+    0, W_IFL_AMMO_9MM, 0, TRUE, FALSE },
+
+   {ARENA_WEAPON_AUTOSHOTGUN, WEAPON_SUBMOD_ARENA, "weapon_autoshotgun", WEAPON_FIRE, 1.0,
+    SKILL4, NOSKILL, FALSE, FALSE,
+    32.0, 2000.0, 0, 0, 200.0,
+    50, FALSE, 100, 1, 0, TRUE, FALSE, FALSE, FALSE, 0.0, 0.0, TRUE, -1, -1,
+    0, W_IFL_AMMO_BUCKSHOT, 0, TRUE, FALSE },
+
+   {ARENA_WEAPON_BURSTRIFLE, WEAPON_SUBMOD_ARENA, "weapon_burstrifle", WEAPON_FIRE_ZOOM, 1.0,
+    SKILL2, NOSKILL, FALSE, FALSE,
+    128.0, 4000.0, 0, 0, 1000.0,
+    60, FALSE, 100, 1, 0, FALSE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, -1, -1,
+    0, W_IFL_AMMO_556, 0, TRUE, FALSE },
 
    /* terminator */
    {0, 0, "", 0, 0.0,
@@ -268,6 +286,16 @@ bot_fire_delay_t valve_fire_delay[NUM_OF_WEAPON_SELECTS] = {
     0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0},
     0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0}},
 
+   {ARENA_WEAPON_9MMSILENCED,
+    0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0},
+    0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0}},
+   {ARENA_WEAPON_AUTOSHOTGUN,
+    0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0},
+    0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0}},
+   {ARENA_WEAPON_BURSTRIFLE,
+    0.05, {0.05, 0.1, 0.2, 0.0, 0.0}, {0.05, 0.1, 0.2, 0.0, 0.0},
+    0.1, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0}},
+
    /* terminator */
    {0, 0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0},
        0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0}}
@@ -288,6 +316,7 @@ int SubmodToSubmodWeaponFlag(int submod)
       case(SUBMOD_BUBBLEMOD): return(WEAPON_SUBMOD_BUBBLEMOD);
       case(SUBMOD_XDM):       return(WEAPON_SUBMOD_XDM);
       case(SUBMOD_OP4):       return(WEAPON_SUBMOD_OP4);
+      case(SUBMOD_ARENA):     return(WEAPON_SUBMOD_ARENA);
    }
 }
 
@@ -717,7 +746,7 @@ qboolean BotWeaponCanAttack(bot_t &pBot, const qboolean GoodWeaponsOnly)
 
 qboolean BotIsWeakWeapon(int iId)
 {
-   return (iId == VALVE_WEAPON_GLOCK);
+   return (iId == VALVE_WEAPON_GLOCK || iId == ARENA_WEAPON_9MMSILENCED);
 }
 
 float BotCombatDisengageTime(const bot_t &pBot)

--- a/bot_weapons.h
+++ b/bot_weapons.h
@@ -66,8 +66,9 @@
 #define WEAPON_SUBMOD_BUBBLEMOD (1<<2)
 #define WEAPON_SUBMOD_XDM (1<<3)
 #define WEAPON_SUBMOD_OP4 (1<<4)
+#define WEAPON_SUBMOD_ARENA (1<<5)
 
-#define WEAPON_SUBMOD_ALL (WEAPON_SUBMOD_HLDM|WEAPON_SUBMOD_SEVS|WEAPON_SUBMOD_BUBBLEMOD|WEAPON_SUBMOD_XDM|WEAPON_SUBMOD_OP4)
+#define WEAPON_SUBMOD_ALL (WEAPON_SUBMOD_HLDM|WEAPON_SUBMOD_SEVS|WEAPON_SUBMOD_BUBBLEMOD|WEAPON_SUBMOD_XDM|WEAPON_SUBMOD_OP4|WEAPON_SUBMOD_ARENA)
 
 typedef struct
 {
@@ -129,7 +130,7 @@ typedef struct
    char ammoName[64];
 } bot_ammo_names_t;
 
-#define NUM_OF_WEAPON_SELECTS 23
+#define NUM_OF_WEAPON_SELECTS 26
 
 extern bot_weapon_select_t weapon_select[NUM_OF_WEAPON_SELECTS];
 extern bot_fire_delay_t fire_delay[NUM_OF_WEAPON_SELECTS];
@@ -169,6 +170,11 @@ enum ammo_low_t {
 #define GEARBOX_WEAPON_SPORELAUNCHER 23
 #define GEARBOX_WEAPON_SNIPERRIFLE   24
 #define GEARBOX_WEAPON_KNIFE         25
+
+// weapon ID values for extra weapons from HL:Arena
+#define ARENA_WEAPON_9MMSILENCED     26
+#define ARENA_WEAPON_AUTOSHOTGUN     27
+#define ARENA_WEAPON_BURSTRIFLE      28
 
 // in normal gravity, how far the longjump hurls us
 #define LONGJUMP_DISTANCE  540

--- a/dll.cpp
+++ b/dll.cpp
@@ -111,6 +111,15 @@ static int CheckSubMod(void)
 {
    int submod = 0;
 
+   // Check game directory first for mods that share description strings
+   char game_dir[256];
+   GetGameDir(game_dir);
+
+   if(stricmp(game_dir, "arena") == 0)
+      submod = SUBMOD_ARENA;
+   else
+   {
+
    // Check if Severians, XDM or Bubblemod
    const char * desc = MDLL_GetGameDescription();
 
@@ -134,8 +143,13 @@ static int CheckSubMod(void)
    else
       submod = SUBMOD_HLDM;
 
+   } // end game_dir else
+
    switch(submod)
    {
+   case SUBMOD_ARENA:
+      UTIL_ConsolePrintf("Half-Life Arena MOD detected.");
+      break;
    case SUBMOD_OP4:
       UTIL_ConsolePrintf("Opposing Force DM detected.");
       break;

--- a/tests/test_bot_weapons.cpp
+++ b/tests/test_bot_weapons.cpp
@@ -158,11 +158,12 @@ static int test_SubmodToSubmodWeaponFlag(void)
    ASSERT_INT(SubmodToSubmodWeaponFlag(SUBMOD_HLDM), WEAPON_SUBMOD_HLDM);
    PASS();
 
-   TEST("all 5 submods map correctly");
+   TEST("all 6 submods map correctly");
    ASSERT_INT(SubmodToSubmodWeaponFlag(SUBMOD_SEVS), WEAPON_SUBMOD_SEVS);
    ASSERT_INT(SubmodToSubmodWeaponFlag(SUBMOD_BUBBLEMOD), WEAPON_SUBMOD_BUBBLEMOD);
    ASSERT_INT(SubmodToSubmodWeaponFlag(SUBMOD_XDM), WEAPON_SUBMOD_XDM);
    ASSERT_INT(SubmodToSubmodWeaponFlag(SUBMOD_OP4), WEAPON_SUBMOD_OP4);
+   ASSERT_INT(SubmodToSubmodWeaponFlag(SUBMOD_ARENA), WEAPON_SUBMOD_ARENA);
    PASS();
 
    TEST("unknown submod defaults to HLDM");
@@ -1137,6 +1138,18 @@ static int test_BotIsWeakWeapon(void)
    ASSERT_INT(BotIsWeakWeapon(VALVE_WEAPON_RPG), FALSE);
    PASS();
 
+   TEST("Silenced 9mm -> TRUE");
+   ASSERT_INT(BotIsWeakWeapon(ARENA_WEAPON_9MMSILENCED), TRUE);
+   PASS();
+
+   TEST("Autoshotgun -> FALSE");
+   ASSERT_INT(BotIsWeakWeapon(ARENA_WEAPON_AUTOSHOTGUN), FALSE);
+   PASS();
+
+   TEST("Burstrifle -> FALSE");
+   ASSERT_INT(BotIsWeakWeapon(ARENA_WEAPON_BURSTRIFLE), FALSE);
+   PASS();
+
    return 0;
 }
 
@@ -1205,6 +1218,117 @@ static int test_BotHasOnlyWeakWeapons(void)
 }
 
 // ============================================================
+// 16. Arena submod weapon tests
+// ============================================================
+
+static int test_arena_weapons(void)
+{
+   printf("Arena submod weapons:\n");
+
+   mock_reset();
+
+   TEST("arena weapons valid in ARENA submod");
+   submod_id = SUBMOD_ARENA;
+   submod_weaponflag = WEAPON_SUBMOD_ARENA;
+   InitWeaponSelect(SUBMOD_ARENA);
+
+   edict_t *pe = mock_alloc_edict();
+   bot_t bot;
+   setup_bot(bot, pe);
+
+   bot_weapon_select_t *silenced = GetWeaponSelect(ARENA_WEAPON_9MMSILENCED);
+   ASSERT_PTR_NOT_NULL(silenced);
+   ASSERT_INT(IsValidWeaponChoose(bot, *silenced), TRUE);
+
+   bot_weapon_select_t *autoshotgun = GetWeaponSelect(ARENA_WEAPON_AUTOSHOTGUN);
+   ASSERT_PTR_NOT_NULL(autoshotgun);
+   ASSERT_INT(IsValidWeaponChoose(bot, *autoshotgun), TRUE);
+
+   bot_weapon_select_t *burstrifle = GetWeaponSelect(ARENA_WEAPON_BURSTRIFLE);
+   ASSERT_PTR_NOT_NULL(burstrifle);
+   ASSERT_INT(IsValidWeaponChoose(bot, *burstrifle), TRUE);
+   PASS();
+
+   TEST("arena weapons excluded in HLDM submod");
+   submod_id = SUBMOD_HLDM;
+   submod_weaponflag = WEAPON_SUBMOD_HLDM;
+   InitWeaponSelect(SUBMOD_HLDM);
+
+   silenced = GetWeaponSelect(ARENA_WEAPON_9MMSILENCED);
+   ASSERT_PTR_NOT_NULL(silenced);
+   ASSERT_INT(IsValidWeaponChoose(bot, *silenced), FALSE);
+
+   autoshotgun = GetWeaponSelect(ARENA_WEAPON_AUTOSHOTGUN);
+   ASSERT_PTR_NOT_NULL(autoshotgun);
+   ASSERT_INT(IsValidWeaponChoose(bot, *autoshotgun), FALSE);
+
+   burstrifle = GetWeaponSelect(ARENA_WEAPON_BURSTRIFLE);
+   ASSERT_PTR_NOT_NULL(burstrifle);
+   ASSERT_INT(IsValidWeaponChoose(bot, *burstrifle), FALSE);
+   PASS();
+
+   TEST("arena weapons excluded in OP4 submod");
+   submod_id = SUBMOD_OP4;
+   submod_weaponflag = WEAPON_SUBMOD_OP4;
+   InitWeaponSelect(SUBMOD_OP4);
+
+   silenced = GetWeaponSelect(ARENA_WEAPON_9MMSILENCED);
+   ASSERT_PTR_NOT_NULL(silenced);
+   ASSERT_INT(IsValidWeaponChoose(bot, *silenced), FALSE);
+   PASS();
+
+   TEST("7 OP4 weapons valid in ARENA submod");
+   submod_id = SUBMOD_ARENA;
+   submod_weaponflag = WEAPON_SUBMOD_ARENA;
+   InitWeaponSelect(SUBMOD_ARENA);
+
+   bot_weapon_select_t *eagle = GetWeaponSelect(GEARBOX_WEAPON_EAGLE);
+   ASSERT_PTR_NOT_NULL(eagle);
+   ASSERT_INT(IsValidWeaponChoose(bot, *eagle), TRUE);
+
+   bot_weapon_select_t *pipewrench = GetWeaponSelect(GEARBOX_WEAPON_PIPEWRENCH);
+   ASSERT_PTR_NOT_NULL(pipewrench);
+   ASSERT_INT(IsValidWeaponChoose(bot, *pipewrench), TRUE);
+
+   bot_weapon_select_t *m249 = GetWeaponSelect(GEARBOX_WEAPON_M249);
+   ASSERT_PTR_NOT_NULL(m249);
+   ASSERT_INT(IsValidWeaponChoose(bot, *m249), TRUE);
+
+   bot_weapon_select_t *displacer = GetWeaponSelect(GEARBOX_WEAPON_DISPLACER);
+   ASSERT_PTR_NOT_NULL(displacer);
+   ASSERT_INT(IsValidWeaponChoose(bot, *displacer), TRUE);
+
+   bot_weapon_select_t *sporelauncher = GetWeaponSelect(GEARBOX_WEAPON_SPORELAUNCHER);
+   ASSERT_PTR_NOT_NULL(sporelauncher);
+   ASSERT_INT(IsValidWeaponChoose(bot, *sporelauncher), TRUE);
+
+   bot_weapon_select_t *sniperrifle = GetWeaponSelect(GEARBOX_WEAPON_SNIPERRIFLE);
+   ASSERT_PTR_NOT_NULL(sniperrifle);
+   ASSERT_INT(IsValidWeaponChoose(bot, *sniperrifle), TRUE);
+
+   bot_weapon_select_t *knife = GetWeaponSelect(GEARBOX_WEAPON_KNIFE);
+   ASSERT_PTR_NOT_NULL(knife);
+   ASSERT_INT(IsValidWeaponChoose(bot, *knife), TRUE);
+   PASS();
+
+   TEST("grapple and shockrifle excluded in ARENA submod");
+   bot_weapon_select_t *grapple = GetWeaponSelect(GEARBOX_WEAPON_GRAPPLE);
+   ASSERT_PTR_NOT_NULL(grapple);
+   ASSERT_INT(IsValidWeaponChoose(bot, *grapple), FALSE);
+
+   bot_weapon_select_t *shockrifle = GetWeaponSelect(GEARBOX_WEAPON_SHOCKRIFLE);
+   ASSERT_PTR_NOT_NULL(shockrifle);
+   ASSERT_INT(IsValidWeaponChoose(bot, *shockrifle), FALSE);
+   PASS();
+
+   // Reset
+   submod_id = SUBMOD_HLDM;
+   submod_weaponflag = WEAPON_SUBMOD_HLDM;
+
+   return 0;
+}
+
+// ============================================================
 // Main
 // ============================================================
 
@@ -1251,6 +1375,8 @@ int main(void)
    rc |= test_BotIsWeakWeapon();
    printf("\n");
    rc |= test_BotHasOnlyWeakWeapons();
+   printf("\n");
+   rc |= test_arena_weapons();
 
    printf("\n%d/%d tests passed.\n", tests_passed, tests_run);
 


### PR DESCRIPTION
## Summary

Closes #43.

- Detect HL:Arena via game directory (`arena`) in `CheckSubMod()`, taking priority over description-based detection since HL:Arena returns "Half-Life" from `MDLL_GetGameDescription()`
- Add weapon definitions for 3 new HL:Arena weapons: silenced Glock (`weapon_9mmsilenced`), auto shotgun (`weapon_autoshotgun`), and burst rifle (`weapon_burstrifle`)
- Enable 7 of 10 OP4 weapons that HL:Arena includes (eagle, pipewrench, M249, displacer, sporelauncher, sniperrifle, knife); grapple, shockrifle, and penguin are absent from HL:Arena
- Add `SUBMOD_ARENA` / `WEAPON_SUBMOD_ARENA` constants and wire them through `SubmodToSubmodWeaponFlag()` and `InitWeaponSelect()`
- Mark silenced 9mm (`weapon_9mmsilenced`) as weak weapon so bots avoid combat when only carrying it

## Test plan

- [x] `test_bot_weapons`: HL:Arena weapons valid in HL:Arena, excluded in HLDM/OP4; 7 OP4 weapons valid in HL:Arena; grapple/shockrifle excluded in HL:Arena; silenced 9mm is weak, autoshotgun/burstrifle are not
- [x] `test_dll`: HL:Arena detected via game_dir; game_dir check overrides description-based detection
- [x] Linux cross-compile build clean
- [x] Win32 cross-compile build clean
- [x] Verified submod detection on listen server with HL:Arena