### PR TITLE
Add weak weapon concept: bots with only Glock avoid combat

### DIFF
--- a/bot.cpp
+++ b/bot.cpp
@@ -132,6 +132,7 @@ static void BotSpawnInit_TimersAndPhysics( bot_t &pBot )
    pBot.b_in_water = 0;
    pBot.b_ducking = 0;
    pBot.b_has_enough_ammo_for_good_weapon = 0;
+   pBot.b_only_has_weak_weapons = 0;
    pBot.b_low_health = 0;
 }
 
@@ -2827,7 +2828,9 @@ static void BotThinkHandleEnemy_FindAndAim(bot_t &pBot)
    edict_t *pEdict = pBot.pEdict;
 
    if(BotWeaponCanAttack(pBot, FALSE) &&
-      ((pBot.b_has_enough_ammo_for_good_weapon && !pBot.b_low_health) || pBot.f_last_time_attacked > gpGlobals->time - 3.0f))
+      ((pBot.b_has_enough_ammo_for_good_weapon && !pBot.b_low_health
+        && !pBot.b_only_has_weak_weapons)
+       || pBot.f_last_time_attacked > gpGlobals->time - BotCombatDisengageTime(pBot)))
    {
       // get enemy
       BotFindEnemy( pBot );
@@ -2892,6 +2895,7 @@ static qboolean BotThinkHandleEnemy(bot_t &pBot)
 
    // Only need to check ammo, since ammo check for weapons includes weapons ;)
    pBot.b_has_enough_ammo_for_good_weapon = !BotAllWeaponsRunningOutOfAmmo(pBot, TRUE);
+   pBot.b_only_has_weak_weapons = BotHasOnlyWeakWeapons(pBot);
 
    BotThinkHandleEnemy_FindAndAim(pBot);
 
@@ -2902,7 +2906,7 @@ static qboolean BotThinkHandleEnemy(bot_t &pBot)
    // does have an enemy?
    if (pBot.pBotEnemy != NULL)
    {
-      if(BotWeaponCanAttack(pBot, FALSE) && (!pBot.b_low_health || pBot.f_last_time_attacked > gpGlobals->time - 3.0f))
+      if(BotWeaponCanAttack(pBot, FALSE) && (!pBot.b_low_health || pBot.f_last_time_attacked > gpGlobals->time - BotCombatDisengageTime(pBot)))
       {
          BotShootAtEnemy( pBot );  // shoot at the enemy
          DidShootAtEnemy = (pBot.pBotEnemy != NULL);

--- a/bot.h
+++ b/bot.h
@@ -160,6 +160,7 @@ typedef struct
    qboolean b_in_water;
    qboolean b_ducking;
    qboolean b_has_enough_ammo_for_good_weapon;
+   qboolean b_only_has_weak_weapons;
    qboolean b_low_health;
 
    int eagle_secondary_state;

--- a/bot_navigate.cpp
+++ b/bot_navigate.cpp
@@ -397,7 +397,8 @@ qboolean BotUpdateTrackSoundGoal( bot_t &pBot )
    // check if target has been erased
    // check our state -> do we want to keep tracking
    if((pBot.f_track_sound_time > 0.0f && pBot.f_track_sound_time < gpGlobals->time) ||
-        !pBot.b_has_enough_ammo_for_good_weapon || pBot.b_low_health)
+        !pBot.b_has_enough_ammo_for_good_weapon || pBot.b_low_health
+        || pBot.b_only_has_weak_weapons)
    {
       if(pBot.waypoint_goal != -1)
       {
@@ -569,7 +570,8 @@ static void BotFindWaypointGoalSearchWeaponAmmo(bot_t &pBot, int &index, float &
    }
 
    // find new weapon if only have shitty weapons or running out of ammo on all weapons
-   if (BotGetGoodWeaponCount(pBot, 1)==0 || !pBot.b_has_enough_ammo_for_good_weapon)
+   if (BotGetGoodWeaponCount(pBot, 1)==0 || !pBot.b_has_enough_ammo_for_good_weapon
+       || pBot.b_only_has_weak_weapons)
    {
       // find weapons that bot can use
       int select_index = -1;
@@ -678,7 +680,8 @@ static void BotFindWaypointGoal( bot_t &pBot )
       // only if not engaging
 
       // find these if have good weapon and no low health
-      if(!pBot.b_low_health && pBot.b_has_enough_ammo_for_good_weapon)
+      if(!pBot.b_low_health && pBot.b_has_enough_ammo_for_good_weapon
+         && !pBot.b_only_has_weak_weapons)
       {
          // find nearest interesting sound that isn't visible
          if (BotFindWaypointGoalTrackSound(pBot, pTrackSoundEdict, index, mindistance, goal_type))

--- a/bot_weapons.cpp
+++ b/bot_weapons.cpp
@@ -715,6 +715,41 @@ qboolean BotWeaponCanAttack(bot_t &pBot, const qboolean GoodWeaponsOnly)
    return(FALSE);
 }
 
+qboolean BotIsWeakWeapon(int iId)
+{
+   return (iId == VALVE_WEAPON_GLOCK);
+}
+
+float BotCombatDisengageTime(const bot_t &pBot)
+{
+   return pBot.b_only_has_weak_weapons ? 1.0f : 3.0f;
+}
+
+qboolean BotHasOnlyWeakWeapons(bot_t &pBot)
+{
+   // Check all carried fire weapons (including fire+zoom, fire+at_feet).
+   // Returns TRUE if every usable fire weapon is weak, or if none exist.
+   bot_weapon_select_t *pSelect = &weapon_select[0];
+   int select_index = -1;
+   while (pSelect[++select_index].iId)
+   {
+      if(!BotIsCarryingWeapon(pBot, pSelect[select_index].iId))
+         continue;
+      if(!IsValidWeaponChoose(pBot, pSelect[select_index]))
+         continue;
+      if(pSelect[select_index].avoid_this_gun ||
+         (pSelect[select_index].type & WEAPON_FIRE) != WEAPON_FIRE)
+         continue;
+      if(!IsValidSecondaryAttack(pBot, pSelect[select_index], 0.0, 0.0, TRUE) &&
+         !IsValidPrimaryAttack(pBot, pSelect[select_index], 0.0, 0.0, TRUE))
+         continue;
+      // Found a usable fire weapon -- is it strong?
+      if(!BotIsWeakWeapon(pSelect[select_index].iId))
+         return FALSE;
+   }
+   return TRUE;
+}
+
 // Check if want to change to better weapon
 int BotGetBetterWeaponChoice(bot_t &pBot, const bot_weapon_select_t &current, const bot_weapon_select_t *pSelect, const float distance, const float height, qboolean *use_primary, qboolean *use_secondary) {
    int select_index;

--- a/bot_weapons.h
+++ b/bot_weapons.h
@@ -221,5 +221,8 @@ int BotGetBetterWeaponChoice(bot_t &pBot, const bot_weapon_select_t &current, co
 
 qboolean IsValidToFireAtTheMoment(bot_t &pBot, const bot_weapon_select_t &select);
 qboolean BotWeaponCanAttack(bot_t &pBot, const qboolean GoodWeaponsOnly);
+qboolean BotIsWeakWeapon(int iId);
+qboolean BotHasOnlyWeakWeapons(bot_t &pBot);
+float BotCombatDisengageTime(const bot_t &pBot);
 qboolean BotGetGoodWeaponCount(bot_t &pBot, const int stop_count);
 #endif // BOT_WEAPONS_H

--- a/tests/test_bot.cpp
+++ b/tests/test_bot.cpp
@@ -5140,6 +5140,141 @@ static int test_BotThink_low_health_attacked_seeks(void)
 }
 
 // ============================================================
+// Phase 6c: BotThink weak weapon behavior
+// ============================================================
+
+// Set up weapon_defs for Glock and Shotgun (needed by weak weapon tests)
+static void setup_weapon_defs_for_weak_weapon_tests(void)
+{
+   // Glock: primary=9mm(slot 1)
+   weapon_defs[VALVE_WEAPON_GLOCK].iId = VALVE_WEAPON_GLOCK;
+   weapon_defs[VALVE_WEAPON_GLOCK].iAmmo1 = 1;
+   weapon_defs[VALVE_WEAPON_GLOCK].iAmmo1Max = 250;
+   weapon_defs[VALVE_WEAPON_GLOCK].iAmmo2 = -1;
+
+   // Shotgun: primary=buckshot(slot 3)
+   weapon_defs[VALVE_WEAPON_SHOTGUN].iId = VALVE_WEAPON_SHOTGUN;
+   weapon_defs[VALVE_WEAPON_SHOTGUN].iAmmo1 = 3;
+   weapon_defs[VALVE_WEAPON_SHOTGUN].iAmmo1Max = 125;
+   weapon_defs[VALVE_WEAPON_SHOTGUN].iAmmo2 = -1;
+}
+
+static int test_BotThink_weak_weapon_no_seek(void)
+{
+   TEST("BotThink: only Glock, not attacked -> no enemy seek");
+   setup_engine_funcs();
+   setup_weapon_defs_for_weak_weapon_tests();
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_alive_bot(bot, e);
+
+   // Give the bot only a Glock with ammo
+   e->v.weapons = (1u << VALVE_WEAPON_GLOCK);
+   bot.m_rgAmmo[1] = 50; // 9mm ammo
+   bot.pBotEnemy = NULL;
+   bot.f_last_time_attacked = 0; // not recently attacked
+
+   BotThink(bot);
+
+   // Bot should NOT have found an enemy (engagement path skipped)
+   ASSERT_PTR_NULL(bot.pBotEnemy);
+   // b_only_has_weak_weapons should be set
+   ASSERT_INT(bot.b_only_has_weak_weapons, TRUE);
+
+   PASS();
+   return 0;
+}
+
+static int test_BotThink_weak_weapon_fights_back(void)
+{
+   TEST("BotThink: only Glock, recently attacked -> fights back");
+   setup_engine_funcs();
+   setup_weapon_defs_for_weak_weapon_tests();
+
+   edict_t *e = mock_alloc_edict();
+   edict_t *enemy = mock_alloc_edict();
+   enemy->v.origin = Vector(200, 0, 0);
+   enemy->v.flags = FL_CLIENT;
+   enemy->v.health = 100;
+   enemy->v.deadflag = DEAD_NO;
+
+   bot_t bot;
+   setup_alive_bot(bot, e);
+
+   // Give the bot only a Glock with ammo
+   e->v.weapons = (1u << VALVE_WEAPON_GLOCK);
+   bot.m_rgAmmo[1] = 50;
+   bot.pBotEnemy = enemy;
+   bot.current_weapon_index = 0;
+   bot.current_weapon.iId = VALVE_WEAPON_GLOCK;
+   bot.current_weapon.iClip = 17;
+   // Recently attacked (within 1 second weak weapon window)
+   bot.f_last_time_attacked = gpGlobals->time - 0.5f;
+
+   BotThink(bot);
+
+   // Bot should have entered combat path (f_pause_time cleared)
+   ASSERT_FLOAT(bot.f_pause_time, 0.0f);
+
+   PASS();
+   return 0;
+}
+
+static int test_BotThink_weak_weapon_disengages_after_1s(void)
+{
+   TEST("BotThink: only Glock, attacked 2s ago -> disengages (1s window)");
+   setup_engine_funcs();
+   setup_weapon_defs_for_weak_weapon_tests();
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_alive_bot(bot, e);
+
+   // Give the bot only a Glock with ammo
+   e->v.weapons = (1u << VALVE_WEAPON_GLOCK);
+   bot.m_rgAmmo[1] = 50;
+   bot.pBotEnemy = NULL;
+   // Attacked 2s ago: outside 1s weak window, inside 3s strong window
+   bot.f_last_time_attacked = gpGlobals->time - 2.0f;
+
+   BotThink(bot);
+
+   // Bot should NOT have found an enemy (disengaged)
+   ASSERT_PTR_NULL(bot.pBotEnemy);
+   ASSERT_INT(bot.b_only_has_weak_weapons, TRUE);
+
+   PASS();
+   return 0;
+}
+
+static int test_BotThink_strong_weapon_seeks(void)
+{
+   TEST("BotThink: Glock + Shotgun -> seeks enemies normally");
+   setup_engine_funcs();
+   setup_weapon_defs_for_weak_weapon_tests();
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_alive_bot(bot, e);
+
+   // Give the bot Glock + Shotgun with ammo
+   e->v.weapons = (1u << VALVE_WEAPON_GLOCK) | (1u << VALVE_WEAPON_SHOTGUN);
+   bot.m_rgAmmo[1] = 50; // 9mm
+   bot.m_rgAmmo[3] = 20; // buckshot
+   bot.pBotEnemy = NULL;
+   bot.f_last_time_attacked = 0;
+
+   BotThink(bot);
+
+   // b_only_has_weak_weapons should be FALSE
+   ASSERT_INT(bot.b_only_has_weak_weapons, FALSE);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
 // main
 // ============================================================
 
@@ -5383,6 +5518,12 @@ int main(void)
    // Phase 6b: f_last_time_attacked retreat logic
    fail |= test_BotThink_low_health_not_attacked_no_seek();
    fail |= test_BotThink_low_health_attacked_seeks();
+
+   // Phase 6c: BotThink weak weapon behavior
+   fail |= test_BotThink_weak_weapon_no_seek();
+   fail |= test_BotThink_weak_weapon_fights_back();
+   fail |= test_BotThink_weak_weapon_disengages_after_1s();
+   fail |= test_BotThink_strong_weapon_seeks();
 
    printf("\n%d/%d tests passed\n", tests_passed, tests_run);
    return fail ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/tests/test_bot_navigate.cpp
+++ b/tests/test_bot_navigate.cpp
@@ -4825,6 +4825,83 @@ static int test_can_jump_up_downward_left_blocked(void)
 }
 
 // ============================================================
+// Weak weapon navigation tests
+// ============================================================
+
+static int test_track_sound_weak_weapons(void)
+{
+   TEST("BotUpdateTrackSoundGoal: weak weapons -> stops tracking");
+   mock_reset();
+   reset_navigate_mocks();
+
+   edict_t *pEdict = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, pEdict);
+
+   bot.wpt_goal_type = WPT_GOAL_TRACK_SOUND;
+   bot.f_track_sound_time = gpGlobals->time + 10.0f;
+   bot.b_low_health = FALSE;
+   bot.b_has_enough_ammo_for_good_weapon = TRUE;
+   bot.b_only_has_weak_weapons = TRUE;
+   bot.waypoint_goal = 5;
+
+   qboolean result = BotUpdateTrackSoundGoal(bot);
+   ASSERT_INT(result, FALSE);
+   ASSERT_INT(bot.waypoint_goal, -1);
+   ASSERT_INT(bot.wpt_goal_type, WPT_GOAL_NONE);
+   PASS();
+   return 0;
+}
+
+static int test_find_waypoint_goal_weak_weapons_no_sound(void)
+{
+   TEST("BotFindWaypointGoal: weak weapons -> skips sound track");
+   mock_reset();
+   reset_navigate_mocks();
+
+   edict_t *pEdict = mock_alloc_edict();
+   edict_t *pSoundSource = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, pEdict);
+   bots[0] = bot;
+   bots[0].pEdict = pEdict;
+
+   bots[0].pBotEnemy = NULL;
+   bots[0].b_low_health = FALSE;
+   bots[0].b_has_enough_ammo_for_good_weapon = TRUE;
+   bots[0].b_only_has_weak_weapons = TRUE;
+   bots[0].f_waypoint_goal_time = 0; // expired
+   pEdict->v.health = 100;
+   skill_settings[bots[0].bot_skill].hearing_sensitivity = 1.0f;
+
+   // Set up sound that would normally be tracked
+   pEdict->v.origin = Vector(0, 0, 0);
+   mock_sounds[0].m_vecOrigin = Vector(100, 0, 0);
+   mock_sounds[0].m_iVolume = 1000;
+   mock_sounds[0].m_iBotOwner = 99;
+   mock_sounds[0].m_pEdict = pSoundSource;
+   mock_sounds[0].m_iNext = SOUNDLIST_EMPTY;
+   mock_active_sound_list = 0;
+
+   setup_waypoint(0, Vector(100, 0, 0));
+   setup_waypoint(1, Vector(0, 0, 0));
+   mock_WaypointFindNearest_result = 0;
+   mock_WaypointDistanceFromTo_result = 100.0f;
+   bots[0].curr_waypoint_index = 1;
+
+   mock_random_float_ret = 0.0f;
+   skill_settings[bots[0].bot_skill].track_sound_time_min = 5.0f;
+   skill_settings[bots[0].bot_skill].track_sound_time_max = 10.0f;
+
+   BotFindWaypointGoal(bots[0]);
+
+   // Should NOT have started tracking sound
+   ASSERT_TRUE(bots[0].wpt_goal_type != WPT_GOAL_TRACK_SOUND);
+   PASS();
+   return 0;
+}
+
+// ============================================================
 // Main
 // ============================================================
 
@@ -5033,6 +5110,10 @@ int main(void)
 
    printf("=== Additional BotCanJumpUp tests ===\n");
    failures += test_can_jump_up_left_side_blocked();
+
+   printf("=== Weak weapon navigation tests ===\n");
+   failures += test_track_sound_weak_weapons();
+   failures += test_find_waypoint_goal_weak_weapons_no_sound();
 
    printf("=== Random-dependent path tests ===\n");
    failures += test_random_turn_180_degree();

--- a/tests/test_bot_weapons.cpp
+++ b/tests/test_bot_weapons.cpp
@@ -1106,6 +1106,105 @@ static int test_MP5_launch_angle(void)
 }
 
 // ============================================================
+// 14. BotIsWeakWeapon tests
+// ============================================================
+
+static int test_BotIsWeakWeapon(void)
+{
+   printf("BotIsWeakWeapon:\n");
+
+   TEST("Glock -> TRUE");
+   ASSERT_INT(BotIsWeakWeapon(VALVE_WEAPON_GLOCK), TRUE);
+   PASS();
+
+   TEST("Shotgun -> FALSE");
+   ASSERT_INT(BotIsWeakWeapon(VALVE_WEAPON_SHOTGUN), FALSE);
+   PASS();
+
+   TEST("MP5 -> FALSE");
+   ASSERT_INT(BotIsWeakWeapon(VALVE_WEAPON_MP5), FALSE);
+   PASS();
+
+   TEST("Crowbar -> FALSE");
+   ASSERT_INT(BotIsWeakWeapon(VALVE_WEAPON_CROWBAR), FALSE);
+   PASS();
+
+   TEST("Egon -> FALSE");
+   ASSERT_INT(BotIsWeakWeapon(VALVE_WEAPON_EGON), FALSE);
+   PASS();
+
+   TEST("RPG -> FALSE");
+   ASSERT_INT(BotIsWeakWeapon(VALVE_WEAPON_RPG), FALSE);
+   PASS();
+
+   return 0;
+}
+
+// ============================================================
+// 15. BotHasOnlyWeakWeapons tests
+// ============================================================
+
+static int test_BotHasOnlyWeakWeapons(void)
+{
+   printf("BotHasOnlyWeakWeapons:\n");
+
+   mock_reset();
+   submod_id = SUBMOD_HLDM;
+   submod_weaponflag = WEAPON_SUBMOD_HLDM;
+   InitWeaponSelect(SUBMOD_HLDM);
+   setup_weapon_defs_valve();
+
+   edict_t *pe = mock_alloc_edict();
+   bot_t bot;
+   setup_bot(bot, pe);
+
+   TEST("no weapons -> TRUE (no usable fire weapons)");
+   pe->v.weapons = 0;
+   ASSERT_INT(BotHasOnlyWeakWeapons(bot), TRUE);
+   PASS();
+
+   TEST("only Glock with ammo -> TRUE");
+   pe->v.weapons = (1u << VALVE_WEAPON_GLOCK);
+   bot.m_rgAmmo[1] = 50; // 9mm
+   ASSERT_INT(BotHasOnlyWeakWeapons(bot), TRUE);
+   PASS();
+
+   TEST("Glock + Shotgun with ammo -> FALSE");
+   pe->v.weapons = (1u << VALVE_WEAPON_GLOCK) | (1u << VALVE_WEAPON_SHOTGUN);
+   bot.m_rgAmmo[1] = 50; // 9mm
+   bot.m_rgAmmo[3] = 20; // buckshot
+   ASSERT_INT(BotHasOnlyWeakWeapons(bot), FALSE);
+   PASS();
+
+   TEST("only Shotgun with ammo -> FALSE");
+   pe->v.weapons = (1u << VALVE_WEAPON_SHOTGUN);
+   bot.m_rgAmmo[3] = 20;
+   ASSERT_INT(BotHasOnlyWeakWeapons(bot), FALSE);
+   PASS();
+
+   TEST("Glock with no ammo -> TRUE (not usable)");
+   pe->v.weapons = (1u << VALVE_WEAPON_GLOCK);
+   bot.m_rgAmmo[1] = 0;
+   ASSERT_INT(BotHasOnlyWeakWeapons(bot), TRUE);
+   PASS();
+
+   TEST("Glock + crowbar (melee skipped) -> TRUE");
+   pe->v.weapons = (1u << VALVE_WEAPON_GLOCK) | (1u << VALVE_WEAPON_CROWBAR);
+   bot.m_rgAmmo[1] = 50;
+   ASSERT_INT(BotHasOnlyWeakWeapons(bot), TRUE);
+   PASS();
+
+   TEST("Glock + handgrenade (avoided skipped) -> TRUE");
+   pe->v.weapons = (1u << VALVE_WEAPON_GLOCK) | (1u << VALVE_WEAPON_HANDGRENADE);
+   bot.m_rgAmmo[1] = 50;
+   bot.m_rgAmmo[11] = 5;
+   ASSERT_INT(BotHasOnlyWeakWeapons(bot), TRUE);
+   PASS();
+
+   return 0;
+}
+
+// ============================================================
 // Main
 // ============================================================
 
@@ -1148,6 +1247,10 @@ int main(void)
    rc |= test_BotGetBetterWeaponChoice();
    printf("\n");
    rc |= test_MP5_launch_angle();
+   printf("\n");
+   rc |= test_BotIsWeakWeapon();
+   printf("\n");
+   rc |= test_BotHasOnlyWeakWeapons();
 
    printf("\n%d/%d tests passed.\n", tests_passed, tests_run);
 


### PR DESCRIPTION
## Summary

- Add `BotIsWeakWeapon()` / `BotHasOnlyWeakWeapons()` helpers identifying the Glock as the only weak weapon
- Add `b_only_has_weak_weapons` state flag computed per-frame in `BotThinkHandleEnemy`
- Bots with only a Glock now prefer seeking better weapons over engaging enemies
- Bots still fight back in self-defense when recently attacked, but disengage faster (1s window vs 3s for normal weapons)
- `BotCombatDisengageTime()` helper returns the appropriate timeout based on weapon state
- Skip and abort sound tracking when only weak weapons available

## Test plan

- [x] `test_bot_weapons`: BotIsWeakWeapon (6 tests) + BotHasOnlyWeakWeapons (7 tests)
- [x] `test_bot`: BotThink weak weapon no-seek, fights-back, disengages-after-1s, and strong-weapon-seeks (4 tests)
- [x] `test_bot_navigate`: track sound stops with weak weapons, find waypoint goal skips sound tracking (2 tests)
- [x] Full test suite: `make test` with cross-compiler