### PR TITLE
Add penguin weapon support (OP4, ID 26)

### DIFF
--- a/bot.cpp
+++ b/bot.cpp
@@ -1446,6 +1446,11 @@ static void BotFindItem_CheckSpecialEntity(bot_t &pBot, edict_t *pent,
    else if (strcmp("monster_snark", item_name) == 0)
    {
    }
+
+   // check if entity is a penguin (OP4 snark reskin)
+   else if (strcmp("monster_penguin", item_name) == 0)
+   {
+   }
 }
 
 

--- a/bot_combat.cpp
+++ b/bot_combat.cpp
@@ -1014,6 +1014,9 @@ static void BotFindEnemySearchMonsters(bot_t &pBot, edict_t *&pNewEnemy, Vector 
       if (FIsClassname(pMonster, "monster_snark"))
          continue; // skip snarks
 
+      if (FIsClassname(pMonster, "monster_penguin"))
+         continue; // skip penguins
+
       if (pMonster->v.health > 4000)
          continue; // skip monsters with large health
 

--- a/bot_weapons.cpp
+++ b/bot_weapons.cpp
@@ -151,6 +151,12 @@ bot_weapon_select_t valve_weapon_select[NUM_OF_WEAPON_SELECTS] =
     20, TRUE, 100, 0, 0, TRUE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, -1, -1,
     W_IFL_KNIFE, 0, 0, FALSE, FALSE },
 
+   {GEARBOX_WEAPON_PENGUIN, WEAPON_SUBMOD_OP4, "weapon_penguin", WEAPON_THROW, 1.0,
+    SKILL3, NOSKILL, FALSE, FALSE,
+    128.0, 800.0, 0, 0, 300.0,
+    20, FALSE, 100, 1, 0, FALSE, FALSE, FALSE, FALSE, 0.0, 0.0, FALSE, -1, -1,
+    0, 0, 0, TRUE, FALSE },
+
    {GEARBOX_WEAPON_GRAPPLE, WEAPON_SUBMOD_OP4, "weapon_grapple", WEAPON_MELEE, 1.0,
     SKILL4, NOSKILL, TRUE, FALSE,
     0.0, 200.0, 0, 0, 100.0,
@@ -282,6 +288,9 @@ bot_fire_delay_t valve_fire_delay[NUM_OF_WEAPON_SELECTS] = {
    {GEARBOX_WEAPON_KNIFE,
     0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0},
     0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0}},
+   {GEARBOX_WEAPON_PENGUIN,
+    0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0},
+    0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0}},
    {GEARBOX_WEAPON_GRAPPLE,
     0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0},
     0.0, {0.0, 0.0, 0.0, 0.0, 0.0}, {0.0, 0.0, 0.0, 0.0, 0.0}},
@@ -356,13 +365,21 @@ void InitWeaponSelect(int submod_id)
 bot_weapon_select_t * GetWeaponSelect(int id)
 {
    bot_weapon_select_t * pSelect = weapon_select;
+   bot_weapon_select_t * pFirst = NULL;
 
    do {
       if(pSelect->iId == id)
-         return(pSelect);
+      {
+         if(!pFirst)
+            pFirst = pSelect;
+
+         // prefer entry matching active submod
+         if(submod_weaponflag && (pSelect->supported_submods & submod_weaponflag))
+            return(pSelect);
+      }
    } while((++pSelect)->iId);
 
-   return(NULL);
+   return(pFirst);
 }
 
 
@@ -746,7 +763,11 @@ qboolean BotWeaponCanAttack(bot_t &pBot, const qboolean GoodWeaponsOnly)
 
 qboolean BotIsWeakWeapon(int iId)
 {
-   return (iId == VALVE_WEAPON_GLOCK || iId == ARENA_WEAPON_9MMSILENCED);
+   if (iId == VALVE_WEAPON_GLOCK)
+      return TRUE;
+   if (iId == ARENA_WEAPON_9MMSILENCED && (submod_weaponflag & WEAPON_SUBMOD_ARENA))
+      return TRUE;
+   return FALSE;
 }
 
 float BotCombatDisengageTime(const bot_t &pBot)

--- a/bot_weapons.h
+++ b/bot_weapons.h
@@ -130,7 +130,7 @@ typedef struct
    char ammoName[64];
 } bot_ammo_names_t;
 
-#define NUM_OF_WEAPON_SELECTS 26
+#define NUM_OF_WEAPON_SELECTS 27
 
 extern bot_weapon_select_t weapon_select[NUM_OF_WEAPON_SELECTS];
 extern bot_fire_delay_t fire_delay[NUM_OF_WEAPON_SELECTS];
@@ -170,6 +170,7 @@ enum ammo_low_t {
 #define GEARBOX_WEAPON_SPORELAUNCHER 23
 #define GEARBOX_WEAPON_SNIPERRIFLE   24
 #define GEARBOX_WEAPON_KNIFE         25
+#define GEARBOX_WEAPON_PENGUIN       26 // OP4 only, not in HL:Arena (shares ID with ARENA_WEAPON_9MMSILENCED)
 
 // weapon ID values for extra weapons from HL:Arena
 #define ARENA_WEAPON_9MMSILENCED     26

--- a/tests/test_bot_combat.cpp
+++ b/tests/test_bot_combat.cpp
@@ -1374,6 +1374,29 @@ static int test_bot_find_enemy_expanded(void)
    mock_trace_line_fn = trace_nohit;
    mock_trace_hull_fn = trace_nohit;
 
+   TEST("monster: penguin skipped");
+   {
+      edict_t *pM = mock_alloc_edict();
+      mock_set_classname(pM, "monster_penguin");
+      pM->v.origin = Vector(100, 0, 0);
+      pM->v.health = 10;
+      pM->v.flags = FL_MONSTER;
+      pM->v.takedamage = DAMAGE_YES;
+      pM->v.deadflag = DEAD_NO;
+      pM->v.solid = SOLID_BBOX;
+      pM->v.view_ofs = Vector(0, 0, 5);
+      BotFindEnemy(testbot);
+      ASSERT_PTR_NULL(testbot.pBotEnemy);
+   }
+   PASS();
+
+   mock_reset();
+   setup_skill_settings();
+   pBotEdict = mock_alloc_edict();
+   setup_bot_for_test(testbot, pBotEdict);
+   mock_trace_line_fn = trace_nohit;
+   mock_trace_hull_fn = trace_nohit;
+
    TEST("monster: high health (>4000) skipped");
    {
       edict_t *pM = mock_alloc_edict();

--- a/tests/test_bot_weapons.cpp
+++ b/tests/test_bot_weapons.cpp
@@ -144,6 +144,12 @@ static void setup_weapon_defs_valve(void)
    weapon_defs[VALVE_WEAPON_SNARK].iAmmo1 = 9;
    weapon_defs[VALVE_WEAPON_SNARK].iAmmo1Max = 15;
    weapon_defs[VALVE_WEAPON_SNARK].iAmmo2 = -1;
+
+   // Penguin (OP4): primary=penguins(12), no secondary
+   weapon_defs[GEARBOX_WEAPON_PENGUIN].iId = GEARBOX_WEAPON_PENGUIN;
+   weapon_defs[GEARBOX_WEAPON_PENGUIN].iAmmo1 = 12;
+   weapon_defs[GEARBOX_WEAPON_PENGUIN].iAmmo1Max = 9;
+   weapon_defs[GEARBOX_WEAPON_PENGUIN].iAmmo2 = -1;
 }
 
 // ============================================================
@@ -1138,8 +1144,15 @@ static int test_BotIsWeakWeapon(void)
    ASSERT_INT(BotIsWeakWeapon(VALVE_WEAPON_RPG), FALSE);
    PASS();
 
-   TEST("Silenced 9mm -> TRUE");
+   TEST("Silenced 9mm in Arena -> TRUE");
+   submod_weaponflag = WEAPON_SUBMOD_ARENA;
    ASSERT_INT(BotIsWeakWeapon(ARENA_WEAPON_9MMSILENCED), TRUE);
+   PASS();
+
+   TEST("ID 26 in OP4 (penguin, not silenced) -> FALSE");
+   submod_weaponflag = WEAPON_SUBMOD_OP4;
+   ASSERT_INT(BotIsWeakWeapon(GEARBOX_WEAPON_PENGUIN), FALSE);
+   submod_weaponflag = WEAPON_SUBMOD_HLDM;
    PASS();
 
    TEST("Autoshotgun -> FALSE");
@@ -1272,9 +1285,10 @@ static int test_arena_weapons(void)
    submod_weaponflag = WEAPON_SUBMOD_OP4;
    InitWeaponSelect(SUBMOD_OP4);
 
+   // GetWeaponSelect(26) returns penguin in OP4 mode (same ID, submod-aware).
    silenced = GetWeaponSelect(ARENA_WEAPON_9MMSILENCED);
    ASSERT_PTR_NOT_NULL(silenced);
-   ASSERT_INT(IsValidWeaponChoose(bot, *silenced), FALSE);
+   ASSERT_STR(silenced->weapon_name, "weapon_penguin");
    PASS();
 
    TEST("7 OP4 weapons valid in ARENA submod");


### PR DESCRIPTION
## Summary
- Add OP4 penguin weapon (ID 26, snark reskin) with weapon select, fire delay, monster entity detection, and enemy search skip
- Weapon config mirrors snark: WEAPON_THROW, range 128-800, SKILL3, ammo on repickup
- No waypoint flag assigned (all 31 usable bits in signed int are taken; penguin is rare)
- Fix GetWeaponSelect to prefer entries matching the active submod when multiple weapons share the same ID (penguin and Arena 9mmsilenced both use ID 26)

## ID 26 collision note
Penguin (OP4) and 9mmsilenced (HL:Arena) both use weapon ID 26. This is correct — the engine assigns the same ID slot to different weapons in different mods. They never coexist at runtime since `supported_submods` filters them (`WEAPON_SUBMOD_OP4` vs `WEAPON_SUBMOD_ARENA`). Penguin is not present in HL:Arena. `GetWeaponSelect` is updated to be submod-aware so it returns the correct entry for the active mod.

## Test plan
- [x] Cross-compile build passes (`make test` with i686-linux-gnu toolchain)
- [ ] Verify penguin pickup/throw works in OP4 multiplayer