### PR TITLE
Add UTIL_IsStringEmpty helper, replace strlen()==0 pattern

### DIFF
--- a/bot_chat.cpp
+++ b/bot_chat.cpp
@@ -214,7 +214,7 @@ static int BotChatTrimTag(const char *original_name, char *out_name, int sizeof_
 
    BotTrimBlanks(out_name, in_name, sizeof(in_name));
 
-   if (strlen(in_name) == 0)  // is name just a tag?
+   if (UTIL_IsStringEmpty(in_name))  // is name just a tag?
    {
       safe_strcopy(in_name, sizeof(in_name), original_name);
 

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -1185,6 +1185,34 @@ static int test_bot_inline_funcs(void)
 }
 
 // ============================================================
+// UTIL_IsStringEmpty tests
+// ============================================================
+
+static int test_is_string_empty(void)
+{
+   printf("UTIL_IsStringEmpty:\n");
+
+   TEST("empty string -> true");
+   ASSERT_TRUE(UTIL_IsStringEmpty(""));
+   PASS();
+
+   TEST("null terminator only -> true");
+   char buf[4] = {'\0', 'a', 'b', '\0'};
+   ASSERT_TRUE(UTIL_IsStringEmpty(buf));
+   PASS();
+
+   TEST("non-empty string -> false");
+   ASSERT_TRUE(!UTIL_IsStringEmpty("hello"));
+   PASS();
+
+   TEST("single char string -> false");
+   ASSERT_TRUE(!UTIL_IsStringEmpty("x"));
+   PASS();
+
+   return 0;
+}
+
+// ============================================================
 // UTIL_VarArgs2 tests
 // ============================================================
 
@@ -1924,6 +1952,9 @@ int main(void)
 
    // bot_inline_funcs.h coverage
    fail |= test_bot_inline_funcs();
+
+   // String helper tests
+   fail |= test_is_string_empty();
 
    // New coverage tests
    fail |= test_varargs2();

--- a/util.h
+++ b/util.h
@@ -4,6 +4,11 @@
 // util.h
 //
 
+inline int UTIL_IsStringEmpty(const char *str)
+{
+   return str[0] == '\0';
+}
+
 void null_terminate_buffer(char *buf, const size_t maxlen);
 
 double UTIL_GetSecs(void);


### PR DESCRIPTION
## Summary
- Add inline `UTIL_IsStringEmpty()` helper in `util.h` that checks `str[0] == '\0'` instead of walking the string with `strlen()`
- Replace `strlen(in_name) == 0` in `bot_chat.cpp` with `UTIL_IsStringEmpty(in_name)`
- Add 4 unit tests for the new helper

Closes #84