### PR TITLE
Add missing include guards to 5 root header files

### DIFF
--- a/bot_client.h
+++ b/bot_client.h
@@ -4,6 +4,8 @@
 // bot_client.h
 //
 
+#ifndef BOT_CLIENT_H
+#define BOT_CLIENT_H
 
 void BotClient_Valve_WeaponList(void *p, int bot_index);
 
@@ -27,3 +29,5 @@ void BotClient_Valve_Damage(void *p, int bot_index);
 void BotClient_Valve_DeathMsg(void *p, int bot_index);
 
 void BotClient_Valve_ScreenFade(void *p, int bot_index);
+
+#endif

--- a/bot_config_init.h
+++ b/bot_config_init.h
@@ -4,6 +4,9 @@
 // bot_config_init.h
 //
 
+#ifndef BOT_CONFIG_INIT_H
+#define BOT_CONFIG_INIT_H
+
 #define MAX_BOT_NAMES 100
 #define MAX_BOT_LOGOS 100
 
@@ -15,3 +18,5 @@ extern char bot_logos[MAX_BOT_LOGOS][16];
 
 void BotLogoInit(void);
 void BotNameInit(void);
+
+#endif

--- a/bot_query_hook.h
+++ b/bot_query_hook.h
@@ -1,3 +1,6 @@
+#ifndef BOT_QUERY_HOOK_H
+#define BOT_QUERY_HOOK_H
+
 #ifdef _WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>
@@ -22,3 +25,5 @@ void UTIL_ConsolePrintf( const char *fmt, ... );
 void BotReplaceConnectionTime(const char * name, float * timeslot);
 
 extern int bot_conntimes;
+
+#endif

--- a/bot_skill.h
+++ b/bot_skill.h
@@ -4,6 +4,9 @@
 // bot_skill.h
 //
 
+#ifndef BOT_SKILL_H
+#define BOT_SKILL_H
+
 #define BEST_BOT_LEVEL 0
 #define WORST_BOT_LEVEL 4
 
@@ -69,3 +72,5 @@ typedef struct
 extern bot_skill_settings_t skill_settings[5];
 
 void ResetSkillsToDefault(void);
+
+#endif

--- a/util.h
+++ b/util.h
@@ -4,6 +4,9 @@
 // util.h
 //
 
+#ifndef UTIL_H
+#define UTIL_H
+
 inline int UTIL_IsStringEmpty(const char *str)
 {
    return str[0] == '\0';
@@ -68,3 +71,5 @@ Vector VecBModelOrigin(edict_t *pEdict);
 qboolean IsAlive(const edict_t *pEdict);
 
 qboolean FInViewCone(const Vector & Origin, edict_t *pEdict);
+
+#endif


### PR DESCRIPTION
## Summary
- Add `#ifndef`/`#define`/`#endif` include guards to the 5 root headers that were missing them:
  `bot_client.h`, `bot_config_init.h`, `bot_query_hook.h`, `bot_skill.h`, `util.h`
- Guard macro names follow existing convention (`UPPERCASE_FILENAME_H`)