### PR TITLE
Add narrow path detection and precision navigation (#94)

### DIFF
--- a/bot.cpp
+++ b/bot.cpp
@@ -120,6 +120,8 @@ static void BotSpawnInit_TimersAndPhysics( bot_t &pBot )
    pBot.waypoint_goal = -1;
    pBot.wpt_goal_type = WPT_GOAL_NONE;
    pBot.trace_last_stuck_wpt = -2;
+   pBot.b_narrow_path = FALSE;
+   pBot.v_prev_waypoint_origin = Vector(0, 0, 0);
    pBot.f_waypoint_goal_time = 0.0;
    pBot.prev_waypoint_distance = 0.0;
    pBot.f_last_item_found = 0.0;
@@ -2414,6 +2416,13 @@ static void BotDoStrafeNormal(bot_t &pBot)
 
    pBot.f_strafe_time = gpGlobals->time + RANDOM_FLOAT2(0.1, 1.0);
 
+   // suppress strafing on narrow paths to prevent falling off
+   if (pBot.b_narrow_path)
+   {
+      pBot.f_strafe_direction = 0.0;
+      return;
+   }
+
    if (RANDOM_LONG2(1, 100) <= skill_settings[pBot.bot_skill].normal_strafe)
    {
       if (RANDOM_LONG2(1, 100) <= 50)
@@ -2610,6 +2619,7 @@ static void BotDoRandomMovement_EvaluateConditions(bot_t &pBot, float moved_dist
 
    // if in combat mode jump more
    jump = (pBot.prev_random_type != 1 && pBot.f_random_jump_time <= gpGlobals->time &&
+           (!pBot.b_narrow_path || pBot.pBotEnemy != NULL) &&
            (moved_distance >= 10.0f || pBot.pBotEnemy != NULL) && pBot.f_move_speed > 1.0f &&
             RANDOM_LONG2(1, 100) <= skill_settings[pBot.bot_skill].random_jump_frequency);
 
@@ -3068,6 +3078,13 @@ static void BotThinkAdjustSpeedForWaypoint(bot_t &pBot)
          // this might be duck-jump waypoint.. check if waypoint is at lower height than current bot origin
          if(waypoints[pBot.curr_waypoint_index].origin.z < pEdict->v.origin.z)
             pEdict->v.button |= IN_DUCK;  // duck down while moving forward
+      }
+
+      // narrow path: slow down for precision
+      if (pBot.b_narrow_path && pBot.f_move_speed > 250.0f)
+      {
+         pBot.f_move_speed = 250.0f;
+         pBot.b_not_maxspeed = TRUE;
       }
    }
 }

--- a/bot.h
+++ b/bot.h
@@ -215,6 +215,8 @@ typedef struct
    float prev_waypoint_distance;
    int wpt_goal_type;
    int trace_last_stuck_wpt;         // dedup: last wpt logged for stuck trace
+   qboolean b_narrow_path;           // currently on narrow geometry (ramp, bridge, cliff)
+   Vector v_prev_waypoint_origin;    // previous waypoint origin for path-following steering
    edict_t *pTrackSoundEdict;        // used when wpt_goal_type == WPT_GOAL_TRACK_SOUND
    float f_track_sound_time;         // how long we track sound?
 

--- a/bot_navigate.cpp
+++ b/bot_navigate.cpp
@@ -275,6 +275,10 @@ static void BotFindWaypoint_UpdateBotState( bot_t &pBot, int select_index )
    pBot.prev_waypoint_index[1] = pBot.prev_waypoint_index[0];
    pBot.prev_waypoint_index[0] = pBot.curr_waypoint_index;
 
+   // save current waypoint origin before switching (for narrow path steering)
+   if (pBot.curr_waypoint_index >= 0)
+      pBot.v_prev_waypoint_origin = waypoints[pBot.curr_waypoint_index].origin;
+
    pBot.curr_waypoint_index = select_index;
    pBot.waypoint_origin = waypoints[select_index].origin;
 
@@ -909,6 +913,10 @@ static qboolean BotHeadTowardWaypointCalcTouching(bot_t &pBot)
    if (pBot.f_exit_water_time >= gpGlobals->time)
       min_distance = 20.0;
 
+   // narrow path: tighter touch distance to stay on the walkable surface
+   if (pBot.b_narrow_path)
+      min_distance = 30.0;
+
    qboolean touching = FALSE;
 
    // did the bot run past the waypoint? (prevent the loop-the-loop problem)
@@ -1040,6 +1048,11 @@ static qboolean BotHeadTowardWaypointFindNextRoute(bot_t &pBot, qboolean waypoin
       if (i != WAYPOINT_UNREACHABLE)  // can we get to the goal from here?
       {
          waypoint_found = TRUE;
+
+         // save current waypoint origin before switching (for narrow path steering)
+         if (pBot.curr_waypoint_index >= 0)
+            pBot.v_prev_waypoint_origin = waypoints[pBot.curr_waypoint_index].origin;
+
          pBot.curr_waypoint_index = i;
          pBot.waypoint_origin = waypoints[i].origin;
 
@@ -1152,6 +1165,84 @@ static void BotHeadTowardWaypoint_DetectLadder( bot_t &pBot )
 }
 
 
+// Check if the bot is on narrow geometry by tracing laterally for drop-offs.
+// Traces perpendicular to the path direction (toward current waypoint).
+static void BotCheckNarrowPath( bot_t &pBot )
+{
+   edict_t *pEdict = pBot.pEdict;
+
+   // skip if on ladder, in water, or no waypoint
+   if (pBot.b_on_ladder || pBot.b_in_water || pBot.curr_waypoint_index == -1)
+   {
+      pBot.b_narrow_path = FALSE;
+      return;
+   }
+
+   // path direction (2D)
+   Vector v_path = pBot.waypoint_origin - pEdict->v.origin;
+   v_path.z = 0;
+   float path_len = v_path.Length();
+   if (path_len < 1.0f)
+   {
+      pBot.b_narrow_path = FALSE;
+      return;
+   }
+   v_path = v_path * (1.0f / path_len);
+
+   // perpendicular (right vector in 2D)
+   Vector v_right = Vector(v_path.y, -v_path.x, 0);
+
+   // trace down to find ground
+   TraceResult tr;
+   Vector v_ground;
+
+   UTIL_TraceDuck(pEdict->v.origin, pEdict->v.origin - Vector(0, 0, 36),
+                  dont_ignore_monsters, pEdict->v.pContainingEntity, &tr);
+   v_ground = tr.vecEndPos;
+   v_ground.z += 1.0f;
+
+   // trace right 48 units from ground level
+   Vector v_right_pos = v_ground + v_right * 48;
+   UTIL_TraceDuck(v_ground, v_right_pos, dont_ignore_monsters,
+                  pEdict->v.pContainingEntity, &tr);
+
+   qboolean right_open = (tr.flFraction > 0.99f);
+   qboolean right_drop = FALSE;
+
+   if (right_open)
+   {
+      // check for drop-off on right
+      UTIL_TraceDuck(v_right_pos, v_right_pos - Vector(0, 0, 47),
+                     dont_ignore_monsters, pEdict->v.pContainingEntity, &tr);
+      right_drop = (tr.flFraction > 0.99f);
+   }
+
+   // trace left 48 units from ground level
+   Vector v_left_pos = v_ground - v_right * 48;
+   UTIL_TraceDuck(v_ground, v_left_pos, dont_ignore_monsters,
+                  pEdict->v.pContainingEntity, &tr);
+
+   qboolean left_open = (tr.flFraction > 0.99f);
+   qboolean left_drop = FALSE;
+
+   if (left_open)
+   {
+      // check for drop-off on left
+      UTIL_TraceDuck(v_left_pos, v_left_pos - Vector(0, 0, 47),
+                     dont_ignore_monsters, pEdict->v.pContainingEntity, &tr);
+      left_drop = (tr.flFraction > 0.99f);
+   }
+
+   qboolean was_narrow = pBot.b_narrow_path;
+   pBot.b_narrow_path = (right_drop || left_drop);
+
+   if (pBot.b_narrow_path && !was_narrow)
+      BotTrace(pBot, "narrow: enter wpt=%d", pBot.curr_waypoint_index);
+   else if (!pBot.b_narrow_path && was_narrow)
+      BotTrace(pBot, "narrow: leave wpt=%d", pBot.curr_waypoint_index);
+}
+
+
 static void BotHeadTowardWaypoint_UpdateViewAngles( bot_t &pBot )
 {
    edict_t *pEdict = pBot.pEdict;
@@ -1159,6 +1250,30 @@ static void BotHeadTowardWaypoint_UpdateViewAngles( bot_t &pBot )
    // keep turning towards the waypoint...
 
    Vector v_direction = pBot.waypoint_origin - pEdict->v.origin;
+
+   // narrow path: follow the path line (prev_wpt -> curr_wpt) instead of aiming directly
+   if (pBot.b_narrow_path && !pBot.v_prev_waypoint_origin.is_zero_vector())
+   {
+      Vector v_path = pBot.waypoint_origin - pBot.v_prev_waypoint_origin;
+      float path_len = v_path.Length();
+
+      if (path_len > 1.0f)
+      {
+         Vector v_path_dir = v_path * (1.0f / path_len);
+
+         // project bot position onto the path line
+         Vector v_bot_offset = pEdict->v.origin - pBot.v_prev_waypoint_origin;
+         float along = DotProduct(v_bot_offset, v_path_dir);
+
+         // aim at a point 64 units ahead on the path line
+         float aim_along = along + 64.0f;
+         if (aim_along > path_len)
+            aim_along = path_len;
+
+         Vector v_aim = pBot.v_prev_waypoint_origin + v_path_dir * aim_along;
+         v_direction = v_aim - pEdict->v.origin;
+      }
+   }
 
    Vector v_angles = UTIL_VecToAngles(v_direction);
 
@@ -1207,6 +1322,8 @@ qboolean BotHeadTowardWaypoint( bot_t &pBot )
    }
 
    BotHeadTowardWaypoint_DetectLadder(pBot);
+
+   BotCheckNarrowPath(pBot);
 
    BotHeadTowardWaypoint_UpdateViewAngles(pBot);
 

--- a/tests/test_bot.cpp
+++ b/tests/test_bot.cpp
@@ -5275,6 +5275,69 @@ static int test_BotThink_strong_weapon_seeks(void)
 }
 
 // ============================================================
+// Narrow path tests
+// ============================================================
+
+static int test_BotDoStrafe_narrow_path_suppresses(void)
+{
+   TEST("BotDoStrafe: narrow path, no enemy -> strafe suppressed");
+   setup_engine_funcs();
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+   bot.pBotEnemy = NULL;
+   bot.b_on_ladder = 0;
+   bot.f_strafe_time = 0; // expired
+   bot.b_narrow_path = TRUE;
+
+   for (int i = 0; i < 5; i++)
+      skill_settings[i].normal_strafe = 100; // always strafe normally
+
+   BotDoStrafe(bot);
+
+   // strafe direction should be 0 (suppressed)
+   ASSERT_FLOAT(bot.f_strafe_direction, 0.0f);
+
+   PASS();
+   return 0;
+}
+
+static int test_BotDoStrafe_narrow_path_with_enemy_still_strafes(void)
+{
+   TEST("BotDoStrafe: narrow path, with enemy -> combat strafe still works");
+   setup_engine_funcs();
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+   bot.b_on_ladder = 0;
+   bot.f_strafe_time = 0;
+   bot.b_narrow_path = TRUE;
+
+   // give bot an enemy
+   edict_t *enemy = mock_alloc_edict();
+   enemy->v.origin = Vector(200, 0, 0);
+   enemy->v.health = 100;
+   enemy->v.deadflag = DEAD_NO;
+   bot.pBotEnemy = enemy;
+
+   for (int i = 0; i < 5; i++)
+      skill_settings[i].battle_strafe = 100;
+
+   mock_random_long_ret = 50;
+
+   BotDoStrafe(bot);
+
+   // Combat strafe should still activate (not suppressed)
+   // f_strafe_time should be updated
+   ASSERT_TRUE(bot.f_strafe_time > gpGlobals->time);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
 // main
 // ============================================================
 
@@ -5524,6 +5587,10 @@ int main(void)
    fail |= test_BotThink_weak_weapon_fights_back();
    fail |= test_BotThink_weak_weapon_disengages_after_1s();
    fail |= test_BotThink_strong_weapon_seeks();
+
+   // Narrow path behavior
+   fail |= test_BotDoStrafe_narrow_path_suppresses();
+   fail |= test_BotDoStrafe_narrow_path_with_enemy_still_strafes();
 
    printf("\n%d/%d tests passed\n", tests_passed, tests_run);
    return fail ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/tests/test_bot_navigate.cpp
+++ b/tests/test_bot_navigate.cpp
@@ -4902,6 +4902,371 @@ static int test_find_waypoint_goal_weak_weapons_no_sound(void)
 }
 
 // ============================================================
+// BotCheckNarrowPath tests
+// ============================================================
+
+// Wide corridor: lateral traces hit walls on both sides -> not narrow
+static int test_narrow_path_wide_corridor(void)
+{
+   TEST("BotCheckNarrowPath: walls both sides -> not narrow");
+   mock_reset();
+   mock_trace_hull_fn = trace_all_hit; // all lateral traces hit walls
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+   e->v.origin = Vector(100, 100, 0);
+   setup_waypoint(0, Vector(200, 100, 0));
+   bot.curr_waypoint_index = 0;
+   bot.waypoint_origin = waypoints[0].origin;
+   bot.b_on_ladder = FALSE;
+   bot.b_in_water = FALSE;
+
+   BotCheckNarrowPath(bot);
+
+   ASSERT_INT(bot.b_narrow_path, FALSE);
+   PASS();
+   return 0;
+}
+
+// Narrow path trace sequence for right drop:
+// 1. trace down to find ground -> hit (fraction < 1)
+// 2. trace right 48u -> clear (fraction ~1.0)
+// 3. trace down 47u from right pos -> clear (fraction ~1.0) = DROP
+// 4. trace left 48u -> hit (fraction < 1)
+static int narrow_trace_call_count;
+static void trace_narrow_right_drop(const float *v1, const float *v2,
+                                     int fNoMonsters, int hullNumber,
+                                     edict_t *pentToSkip, TraceResult *ptr)
+{
+   (void)fNoMonsters; (void)hullNumber; (void)pentToSkip;
+   narrow_trace_call_count++;
+
+   switch (narrow_trace_call_count)
+   {
+   case 1: // trace down to ground -> hit floor
+      ptr->flFraction = 0.5f;
+      ptr->vecEndPos[0] = v1[0];
+      ptr->vecEndPos[1] = v1[1];
+      ptr->vecEndPos[2] = v1[2] - 18.0f;
+      break;
+   case 2: // trace right -> clear (open)
+      ptr->flFraction = 1.0f;
+      ptr->vecEndPos[0] = v2[0];
+      ptr->vecEndPos[1] = v2[1];
+      ptr->vecEndPos[2] = v2[2];
+      break;
+   case 3: // trace down from right -> clear (drop-off!)
+      ptr->flFraction = 1.0f;
+      ptr->vecEndPos[0] = v2[0];
+      ptr->vecEndPos[1] = v2[1];
+      ptr->vecEndPos[2] = v2[2];
+      break;
+   case 4: // trace left -> hit wall
+      ptr->flFraction = 0.3f;
+      ptr->vecEndPos[0] = (v1[0] + v2[0]) / 2;
+      ptr->vecEndPos[1] = (v1[1] + v2[1]) / 2;
+      ptr->vecEndPos[2] = (v1[2] + v2[2]) / 2;
+      break;
+   default:
+      ptr->flFraction = 0.5f;
+      ptr->vecEndPos[0] = (v1[0] + v2[0]) / 2;
+      ptr->vecEndPos[1] = (v1[1] + v2[1]) / 2;
+      ptr->vecEndPos[2] = (v1[2] + v2[2]) / 2;
+      break;
+   }
+   ptr->pHit = NULL;
+}
+
+static int test_narrow_path_drop_right(void)
+{
+   TEST("BotCheckNarrowPath: drop on right -> narrow");
+   mock_reset();
+   narrow_trace_call_count = 0;
+   mock_trace_hull_fn = trace_narrow_right_drop;
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+   e->v.origin = Vector(100, 100, 0);
+   setup_waypoint(0, Vector(200, 100, 0));
+   bot.curr_waypoint_index = 0;
+   bot.waypoint_origin = waypoints[0].origin;
+   bot.b_on_ladder = FALSE;
+   bot.b_in_water = FALSE;
+   bot.b_narrow_path = FALSE;
+
+   BotCheckNarrowPath(bot);
+
+   ASSERT_INT(bot.b_narrow_path, TRUE);
+   PASS();
+   return 0;
+}
+
+// Left drop: ground hit, right hits wall, left clear, left down clear
+static void trace_narrow_left_drop(const float *v1, const float *v2,
+                                    int fNoMonsters, int hullNumber,
+                                    edict_t *pentToSkip, TraceResult *ptr)
+{
+   (void)fNoMonsters; (void)hullNumber; (void)pentToSkip;
+   narrow_trace_call_count++;
+
+   switch (narrow_trace_call_count)
+   {
+   case 1: // ground
+      ptr->flFraction = 0.5f;
+      ptr->vecEndPos[0] = v1[0]; ptr->vecEndPos[1] = v1[1]; ptr->vecEndPos[2] = v1[2] - 18.0f;
+      break;
+   case 2: // right -> wall
+      ptr->flFraction = 0.3f;
+      ptr->vecEndPos[0] = (v1[0]+v2[0])/2; ptr->vecEndPos[1] = (v1[1]+v2[1])/2; ptr->vecEndPos[2] = (v1[2]+v2[2])/2;
+      break;
+   case 3: // left -> clear
+      ptr->flFraction = 1.0f;
+      ptr->vecEndPos[0] = v2[0]; ptr->vecEndPos[1] = v2[1]; ptr->vecEndPos[2] = v2[2];
+      break;
+   case 4: // left down -> clear (drop!)
+      ptr->flFraction = 1.0f;
+      ptr->vecEndPos[0] = v2[0]; ptr->vecEndPos[1] = v2[1]; ptr->vecEndPos[2] = v2[2];
+      break;
+   default:
+      ptr->flFraction = 0.5f;
+      ptr->vecEndPos[0] = (v1[0]+v2[0])/2; ptr->vecEndPos[1] = (v1[1]+v2[1])/2; ptr->vecEndPos[2] = (v1[2]+v2[2])/2;
+      break;
+   }
+   ptr->pHit = NULL;
+}
+
+static int test_narrow_path_drop_left(void)
+{
+   TEST("BotCheckNarrowPath: drop on left -> narrow");
+   mock_reset();
+   narrow_trace_call_count = 0;
+   mock_trace_hull_fn = trace_narrow_left_drop;
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+   e->v.origin = Vector(100, 100, 0);
+   setup_waypoint(0, Vector(200, 100, 0));
+   bot.curr_waypoint_index = 0;
+   bot.waypoint_origin = waypoints[0].origin;
+   bot.b_on_ladder = FALSE;
+   bot.b_in_water = FALSE;
+   bot.b_narrow_path = FALSE;
+
+   BotCheckNarrowPath(bot);
+
+   ASSERT_INT(bot.b_narrow_path, TRUE);
+   PASS();
+   return 0;
+}
+
+static int test_narrow_path_walls_both_sides(void)
+{
+   TEST("BotCheckNarrowPath: walls both sides, no drop -> not narrow");
+   mock_reset();
+
+   // ground hit, right hits wall, left hits wall
+   static int call;
+   call = 0;
+   mock_trace_hull_fn = [](const float *v1, const float *v2,
+                           int, int, edict_t *, TraceResult *ptr) {
+      call++;
+      if (call == 1) { // ground
+         ptr->flFraction = 0.5f;
+         ptr->vecEndPos[0] = v1[0]; ptr->vecEndPos[1] = v1[1]; ptr->vecEndPos[2] = v1[2] - 18.0f;
+      } else { // all lateral traces hit walls
+         ptr->flFraction = 0.3f;
+         ptr->vecEndPos[0] = (v1[0]+v2[0])/2; ptr->vecEndPos[1] = (v1[1]+v2[1])/2; ptr->vecEndPos[2] = (v1[2]+v2[2])/2;
+      }
+      ptr->pHit = NULL;
+   };
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+   e->v.origin = Vector(100, 100, 0);
+   setup_waypoint(0, Vector(200, 100, 0));
+   bot.curr_waypoint_index = 0;
+   bot.waypoint_origin = waypoints[0].origin;
+   bot.b_on_ladder = FALSE;
+   bot.b_in_water = FALSE;
+
+   BotCheckNarrowPath(bot);
+
+   ASSERT_INT(bot.b_narrow_path, FALSE);
+   PASS();
+   return 0;
+}
+
+static int test_narrow_path_on_ladder_skip(void)
+{
+   TEST("BotCheckNarrowPath: on ladder -> skip, not narrow");
+   mock_reset();
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+   bot.b_on_ladder = TRUE;
+   bot.b_narrow_path = TRUE; // was narrow, should be cleared
+
+   BotCheckNarrowPath(bot);
+
+   ASSERT_INT(bot.b_narrow_path, FALSE);
+   PASS();
+   return 0;
+}
+
+static int test_narrow_path_no_waypoint_skip(void)
+{
+   TEST("BotCheckNarrowPath: no waypoint -> skip, not narrow");
+   mock_reset();
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+   bot.curr_waypoint_index = -1;
+   bot.b_narrow_path = TRUE;
+
+   BotCheckNarrowPath(bot);
+
+   ASSERT_INT(bot.b_narrow_path, FALSE);
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// Narrow path CalcTouching test
+// ============================================================
+
+static int test_narrow_path_touch_distance(void)
+{
+   TEST("CalcTouching: narrow path uses tighter distance (30)");
+   mock_reset();
+   mock_trace_hull_fn = trace_all_clear;
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+
+   setup_waypoint(0, Vector(135, 0, 0)); // 35 units away
+   bot.curr_waypoint_index = 0;
+   bot.waypoint_origin = waypoints[0].origin;
+   e->v.origin = Vector(100, 0, 0);
+   bot.prev_waypoint_distance = 40.0f;
+
+   // Not narrow: 35 < 50 -> touching
+   bot.b_narrow_path = FALSE;
+   ASSERT_INT(BotHeadTowardWaypointCalcTouching(bot), TRUE);
+
+   // Reset
+   bot.prev_waypoint_distance = 40.0f;
+
+   // Narrow: 35 > 30 -> NOT touching
+   bot.b_narrow_path = TRUE;
+   ASSERT_INT(BotHeadTowardWaypointCalcTouching(bot), FALSE);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// Narrow path steering tests
+// ============================================================
+
+static int test_narrow_path_steering(void)
+{
+   TEST("UpdateViewAngles: narrow path aims differently than direct");
+   mock_reset();
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+
+   // Path goes along +Y axis: prev=(0,10,0) curr=(0,200,0)
+   // Bot is offset to the right at (30,50,0) - early on the path
+   setup_waypoint(0, Vector(0, 200, 0));
+   bot.curr_waypoint_index = 0;
+   bot.waypoint_origin = waypoints[0].origin;
+   bot.v_prev_waypoint_origin = Vector(0, 10, 0); // non-zero prev
+   e->v.origin = Vector(30, 50, 0);
+
+   // First get direct aim yaw (not narrow)
+   bot.b_narrow_path = FALSE;
+   BotHeadTowardWaypoint_UpdateViewAngles(bot);
+   float direct_yaw = e->v.ideal_yaw;
+
+   // Now get path-following aim yaw (narrow)
+   bot.b_narrow_path = TRUE;
+   BotHeadTowardWaypoint_UpdateViewAngles(bot);
+   float path_yaw = e->v.ideal_yaw;
+
+   // Path-following should produce a different yaw than direct aim
+   ASSERT_TRUE(fabs(path_yaw - direct_yaw) > 1.0f);
+
+   PASS();
+   return 0;
+}
+
+static int test_narrow_path_steering_no_prev(void)
+{
+   TEST("UpdateViewAngles: narrow path, no prev waypoint -> direct aim");
+   mock_reset();
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+
+   setup_waypoint(0, Vector(200, 0, 0));
+   bot.curr_waypoint_index = 0;
+   bot.waypoint_origin = waypoints[0].origin;
+   bot.v_prev_waypoint_origin = Vector(0, 0, 0); // zero = no prev
+   bot.b_narrow_path = TRUE;
+   e->v.origin = Vector(100, 50, 0);
+
+   BotHeadTowardWaypoint_UpdateViewAngles(bot);
+
+   // Should fall back to direct aim since prev is zero vector
+   Vector direct = Vector(200, 0, 0) - Vector(100, 50, 0);
+   float expected_yaw = UTIL_VecToAngles(direct).y;
+   ASSERT_FLOAT_NEAR(e->v.ideal_yaw, expected_yaw, 1.0f);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// BotFindWaypoint_UpdateBotState prev origin tracking
+// ============================================================
+
+static int test_update_bot_state_saves_prev_origin(void)
+{
+   TEST("UpdateBotState: saves prev waypoint origin before switching");
+   mock_reset();
+
+   edict_t *e = mock_alloc_edict();
+   bot_t bot;
+   setup_bot_for_test(bot, e);
+
+   setup_waypoint(5, Vector(100, 200, 300));
+   setup_waypoint(10, Vector(400, 500, 600));
+
+   bot.curr_waypoint_index = 5;
+   bot.waypoint_origin = waypoints[5].origin;
+
+   BotFindWaypoint_UpdateBotState(bot, 10);
+
+   ASSERT_INT(bot.curr_waypoint_index, 10);
+   ASSERT_FLOAT(bot.v_prev_waypoint_origin.x, 100.0f);
+   ASSERT_FLOAT(bot.v_prev_waypoint_origin.y, 200.0f);
+   ASSERT_FLOAT(bot.v_prev_waypoint_origin.z, 300.0f);
+
+   PASS();
+   return 0;
+}
+
+// ============================================================
 // Main
 // ============================================================
 
@@ -5133,6 +5498,24 @@ int main(void)
    failures += test_can_jump_up_right_duck_blocked();
    failures += test_can_jump_up_downward_right_blocked();
    failures += test_can_jump_up_downward_left_blocked();
+
+   printf("=== BotCheckNarrowPath tests ===\n");
+   failures += test_narrow_path_wide_corridor();
+   failures += test_narrow_path_drop_right();
+   failures += test_narrow_path_drop_left();
+   failures += test_narrow_path_walls_both_sides();
+   failures += test_narrow_path_on_ladder_skip();
+   failures += test_narrow_path_no_waypoint_skip();
+
+   printf("=== Narrow path CalcTouching tests ===\n");
+   failures += test_narrow_path_touch_distance();
+
+   printf("=== Narrow path UpdateViewAngles tests ===\n");
+   failures += test_narrow_path_steering();
+   failures += test_narrow_path_steering_no_prev();
+
+   printf("=== BotFindWaypoint_UpdateBotState prev origin tests ===\n");
+   failures += test_update_bot_state_saves_prev_origin();
 
    printf("\n%d/%d tests passed\n", tests_passed, tests_run);
    return failures ? 1 : 0;


### PR DESCRIPTION
## Summary
- Detect narrow geometry (ramps, bridges, cliff edges) by tracing laterally for drop-offs
- When narrow path detected, adjust bot behavior for precision:
  - Path-following steering along prev_wpt->curr_wpt line instead of direct waypoint aim
  - Suppress normal strafing to prevent falling off edges
  - Cap speed at 250 u/s for better course correction
  - Tighten waypoint touch distance from 50 to 30 units
  - Suppress random jumping (only when no enemy)
- BotTrace logs `narrow: enter/leave` events

## Detection
`BotCheckNarrowPath()` traces 48 units perpendicular to the path direction, then 47 units down. If either side has a drop-off, the path is "narrow". Runs every BotThink frame (already throttled to ~30 fps). Cost: 4-6 hull traces per frame when navigating.

## What it doesn't change
- Combat strafing (still active with enemy)
- Random jumping during combat (still active with enemy)
- Any enemy targeting or weapon behavior

## Context
Addresses #94. Investigated via trace logging (#89) and BSP visualization tools (#95). Example: varrock map wpt 644, narrow ramp where bots repeatedly fell off due to imprecise movement.

## Test plan
- [x] 12 new unit tests covering all behavior changes
- [x] All existing tests pass (169/169 navigate, 178/178 bot)
- [x] Linux and Win32 cross-compile
- [x] Live testing on HLDS (2 days, 7 maps, 581 log files)

## Live test results
Tested on HLDS server over 2 days across 7 maps (83 sessions/map):
- **Zero fall deaths** on all maps (previously bots fell off narrow paths)
- **Varrock wpt 644** (the problematic narrow ramp): stuck rate dropped from **12.98/session to 2.14/session (~6x reduction)**
- **Overall varrock stuck rate** halved: ~70/session down to ~32/session
- Narrow path detection active on 579 unique waypoints on varrock alone (6000+ activations/day)