### PR TITLE
Split release packages into separate Linux and Windows archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Update package list for i386
@@ -22,7 +22,7 @@ jobs:
         run: CXX="g++ -m32" make valgrind
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Update package list for i386
@@ -54,7 +54,7 @@ jobs:
           path: tests/coverage_report
 
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Update package list for i386
@@ -70,7 +70,7 @@ jobs:
           path: jk_botti_mm_i386.so
 
   build-windows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install packages
@@ -83,29 +83,47 @@ jobs:
           name: windows-binary
           path: jk_botti_mm.dll
 
-  release-artifact:
-    needs: [test, build-linux, build-windows]
-    runs-on: ubuntu-latest
+  release-linux:
+    needs: [test, build-linux]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Download Linux binary
         uses: actions/download-artifact@v4
         with:
           name: linux-binary
-          path: addons/jk_botti/dlls
+          path: staging
+      - name: Prepare release directory
+        run: |
+          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
+          cp staging/jk_botti_mm_i386.so addons/jk_botti/dlls/
+          ln -sf jk_botti_mm_i386.so addons/jk_botti/dlls/jk_botti_mm.so
+      - name: Create release archive
+        run: tar c addons | xz > jk_botti-snapshot-linux_ubuntu2404.tar.xz
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jk_botti-snapshot-linux_ubuntu2404
+          path: jk_botti-snapshot-linux_ubuntu2404.tar.xz
+
+  release-windows:
+    needs: [test, build-windows]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
       - name: Download Windows binary
         uses: actions/download-artifact@v4
         with:
           name: windows-binary
-          path: addons/jk_botti/dlls
+          path: staging
       - name: Prepare release directory
         run: |
-          rm -f addons/jk_botti/dlls/.empty_dir
-          ln -sf jk_botti_mm_i386.so addons/jk_botti/dlls/jk_botti_mm.so
+          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
+          cp staging/jk_botti_mm.dll addons/jk_botti/dlls/
       - name: Create release archive
-        run: tar c addons | xz > jk_botti-snapshot-release.tar.xz
+        run: tar c addons | xz > jk_botti-snapshot-win32.tar.xz
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: jk_botti-snapshot-release
-          path: jk_botti-snapshot-release.tar.xz
+          name: jk_botti-snapshot-win32
+          path: jk_botti-snapshot-win32.tar.xz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,47 +83,8 @@ jobs:
           name: windows-binary
           path: jk_botti_mm.dll
 
-  release-linux:
-    needs: [test, build-linux]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download Linux binary
-        uses: actions/download-artifact@v4
-        with:
-          name: linux-binary
-          path: staging
-      - name: Prepare release directory
-        run: |
-          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
-          cp staging/jk_botti_mm_i386.so addons/jk_botti/dlls/
-          ln -sf jk_botti_mm_i386.so addons/jk_botti/dlls/jk_botti_mm.so
-      - name: Create release archive
-        run: tar c addons | xz > jk_botti-snapshot-linux_ubuntu2404.tar.xz
-      - name: Upload release artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: jk_botti-snapshot-linux_ubuntu2404
-          path: jk_botti-snapshot-linux_ubuntu2404.tar.xz
-
-  release-windows:
-    needs: [test, build-windows]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download Windows binary
-        uses: actions/download-artifact@v4
-        with:
-          name: windows-binary
-          path: staging
-      - name: Prepare release directory
-        run: |
-          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
-          cp staging/jk_botti_mm.dll addons/jk_botti/dlls/
-      - name: Create release archive
-        run: tar c addons | xz > jk_botti-snapshot-win32.tar.xz
-      - name: Upload release artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: jk_botti-snapshot-win32
-          path: jk_botti-snapshot-win32.tar.xz
+  package:
+    needs: [test, build-linux, build-windows]
+    uses: ./.github/workflows/package.yml
+    with:
+      version: snapshot

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,78 @@
+name: Package
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      create_release:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  package-linux:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Linux binary
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-binary
+          path: staging
+      - name: Prepare release directory
+        run: |
+          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
+          cp staging/jk_botti_mm_i386.so addons/jk_botti/dlls/
+          ln -sf jk_botti_mm_i386.so addons/jk_botti/dlls/jk_botti_mm.so
+      - name: Create release archive
+        run: tar c addons | xz > jk_botti-${{ inputs.version }}-linux_ubuntu2404.tar.xz
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jk_botti-${{ inputs.version }}-linux_ubuntu2404
+          path: jk_botti-${{ inputs.version }}-linux_ubuntu2404.tar.xz
+
+  package-windows:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Windows binary
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-binary
+          path: staging
+      - name: Prepare release directory
+        run: |
+          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
+          cp staging/jk_botti_mm.dll addons/jk_botti/dlls/
+      - name: Create release archive
+        run: tar c addons | xz > jk_botti-${{ inputs.version }}-win32.tar.xz
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jk_botti-${{ inputs.version }}-win32
+          path: jk_botti-${{ inputs.version }}-win32.tar.xz
+
+  create-release:
+    if: ${{ inputs.create_release }}
+    needs: [package-linux, package-windows]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Download Linux archive
+        uses: actions/download-artifact@v4
+        with:
+          name: jk_botti-${{ inputs.version }}-linux_ubuntu2404
+      - name: Download Windows archive
+        uses: actions/download-artifact@v4
+        with:
+          name: jk_botti-${{ inputs.version }}-win32
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            jk_botti-${{ inputs.version }}-linux_ubuntu2404.tar.xz
+            jk_botti-${{ inputs.version }}-win32.tar.xz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   validate-tag:
     runs-on: ubuntu-24.04
     outputs:
+      version: ${{ steps.parse.outputs.VERSION }}
       ver_major: ${{ steps.parse.outputs.VER_MAJOR }}
       ver_minor: ${{ steps.parse.outputs.VER_MINOR }}
       ver_note: ${{ steps.parse.outputs.VER_NOTE }}
@@ -18,6 +19,7 @@ jobs:
         run: |
           TAG=${GITHUB_REF#refs/tags/}
           if [[ "$TAG" =~ ^v([0-9]+)\.([0-9]+)(.*)$ ]]; then
+            echo "VERSION=$TAG" >> "$GITHUB_OUTPUT"
             echo "VER_MAJOR=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
             echo "VER_MINOR=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
             echo "VER_NOTE=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
@@ -58,40 +60,11 @@ jobs:
           name: windows-binary
           path: jk_botti_mm.dll
 
-  release:
+  package:
     needs: [validate-tag, build-linux, build-windows]
-    runs-on: ubuntu-24.04
+    uses: ./.github/workflows/package.yml
+    with:
+      version: ${{ needs.validate-tag.outputs.version }}
+      create_release: true
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Get version
-        id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-      - name: Download Linux binary
-        uses: actions/download-artifact@v4
-        with:
-          name: linux-binary
-          path: staging/linux
-      - name: Download Windows binary
-        uses: actions/download-artifact@v4
-        with:
-          name: windows-binary
-          path: staging/windows
-      - name: Create Linux release archive
-        run: |
-          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
-          cp staging/linux/jk_botti_mm_i386.so addons/jk_botti/dlls/
-          ln -sf jk_botti_mm_i386.so addons/jk_botti/dlls/jk_botti_mm.so
-          tar c addons | xz > jk_botti-${{ steps.get_version.outputs.VERSION }}-linux_ubuntu2404.tar.xz
-      - name: Create Windows release archive
-        run: |
-          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
-          cp staging/windows/jk_botti_mm.dll addons/jk_botti/dlls/
-          tar c addons | xz > jk_botti-${{ steps.get_version.outputs.VERSION }}-win32.tar.xz
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            jk_botti-${{ steps.get_version.outputs.VERSION }}-linux_ubuntu2404.tar.xz
-            jk_botti-${{ steps.get_version.outputs.VERSION }}-win32.tar.xz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   validate-tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       ver_major: ${{ steps.parse.outputs.VER_MAJOR }}
       ver_minor: ${{ steps.parse.outputs.VER_MINOR }}
@@ -28,7 +28,7 @@ jobs:
 
   build-linux:
     needs: validate-tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Update package list for i386
@@ -45,7 +45,7 @@ jobs:
 
   build-windows:
     needs: validate-tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install packages
@@ -60,7 +60,7 @@ jobs:
 
   release:
     needs: [validate-tag, build-linux, build-windows]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -72,19 +72,26 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: linux-binary
-          path: addons/jk_botti/dlls
+          path: staging/linux
       - name: Download Windows binary
         uses: actions/download-artifact@v4
         with:
           name: windows-binary
-          path: addons/jk_botti/dlls
-      - name: Prepare release directory
+          path: staging/windows
+      - name: Create Linux release archive
         run: |
-          rm -f addons/jk_botti/dlls/.empty_dir
+          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
+          cp staging/linux/jk_botti_mm_i386.so addons/jk_botti/dlls/
           ln -sf jk_botti_mm_i386.so addons/jk_botti/dlls/jk_botti_mm.so
-      - name: Create release archive
-        run: tar c addons | xz > jk_botti-${{ steps.get_version.outputs.VERSION }}-release.tar.xz
+          tar c addons | xz > jk_botti-${{ steps.get_version.outputs.VERSION }}-linux_ubuntu2404.tar.xz
+      - name: Create Windows release archive
+        run: |
+          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
+          cp staging/windows/jk_botti_mm.dll addons/jk_botti/dlls/
+          tar c addons | xz > jk_botti-${{ steps.get_version.outputs.VERSION }}-win32.tar.xz
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: jk_botti-${{ steps.get_version.outputs.VERSION }}-release.tar.xz
+          files: |
+            jk_botti-${{ steps.get_version.outputs.VERSION }}-linux_ubuntu2404.tar.xz
+            jk_botti-${{ steps.get_version.outputs.VERSION }}-win32.tar.xz


### PR DESCRIPTION
## Summary
- Pin all CI runners to `ubuntu-24.04` instead of floating `ubuntu-latest` (#96)
- Split combined release archive into platform-specific packages:
  - `jk_botti-<version>-linux_ubuntu2404.tar.xz` (Linux `.so` + symlink)
  - `jk_botti-<version>-win32.tar.xz` (Windows `.dll`)
- Extract shared `package.yml` reusable workflow called by both `ci.yml` and `release.yml`, so CI exercises the same packaging code path as actual releases

## Test plan
- [x] CI builds pass for both Linux and Windows
- [x] Snapshot artifacts uploaded as separate platform packages
- [x] `create-release` job correctly skipped for CI (non-tag) builds
- [ ] Verify tagged release creates GitHub release with both archives