### PR TITLE
Add Docker-based Ubuntu 18.04 i386 build for older Linux servers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,77 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      ver_major:
+        required: false
+        type: string
+        default: ''
+      ver_minor:
+        required: false
+        type: string
+        default: ''
+      ver_note:
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update package list for i386
+        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
+      - name: Install packages
+        run: sudo apt-get -y install build-essential g++-multilib
+      - name: Build
+        run: |
+          VERFLAGS=""
+          if [ -n "${{ inputs.ver_major }}" ]; then
+            VERFLAGS="VER_MAJOR=${{ inputs.ver_major }} VER_MINOR=${{ inputs.ver_minor }} VER_NOTE=${{ inputs.ver_note }}"
+          fi
+          CC="gcc -m32" CXX="g++ -m32" AR="ar rc" RANLIB="ranlib" make -j4 $VERFLAGS
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-binary
+          path: jk_botti_mm_i386.so
+
+  build-linux-bionic:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build in Ubuntu 18.04 i386 container
+        run: |
+          VERFLAGS=""
+          if [ -n "${{ inputs.ver_major }}" ]; then
+            VERFLAGS="VER_MAJOR=${{ inputs.ver_major }} VER_MINOR=${{ inputs.ver_minor }} VER_NOTE=${{ inputs.ver_note }}"
+          fi
+          docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace \
+            lpenz/ubuntu-bionic-i386 \
+            bash -c "apt-get -y update && apt-get -y install build-essential g++ make && make -j4 $VERFLAGS"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-bionic-binary
+          path: jk_botti_mm_i386.so
+
+  build-windows:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install packages
+        run: sudo apt-get -y update && sudo apt-get -y install gcc-mingw-w64 g++-mingw-w64
+      - name: Build
+        run: |
+          VERFLAGS=""
+          if [ -n "${{ inputs.ver_major }}" ]; then
+            VERFLAGS="VER_MAJOR=${{ inputs.ver_major }} VER_MINOR=${{ inputs.ver_minor }} VER_NOTE=${{ inputs.ver_note }}"
+          fi
+          make -j4 OSTYPE=win32 $VERFLAGS
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-binary
+          path: jk_botti_mm.dll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,21 @@ jobs:
           name: linux-binary
           path: jk_botti_mm_i386.so
 
+  build-linux-bionic:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build in Ubuntu 18.04 i386 container
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace \
+            lpenz/ubuntu-bionic-i386 \
+            bash -c "apt-get -y update && apt-get -y install build-essential g++ make && make -j4"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-bionic-binary
+          path: jk_botti_mm_i386.so
+
   build-windows:
     runs-on: ubuntu-24.04
     steps:
@@ -84,7 +99,7 @@ jobs:
           path: jk_botti_mm.dll
 
   package:
-    needs: [test, build-linux, build-windows]
+    needs: [test, build-linux, build-linux-bionic, build-windows]
     uses: ./.github/workflows/package.yml
     with:
       version: snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,53 +53,11 @@ jobs:
           name: coverage-report
           path: tests/coverage_report
 
-  build-linux:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Update package list for i386
-        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
-      - name: Install packages
-        run: sudo apt-get -y install build-essential g++-multilib
-      - name: Build
-        run: CC="gcc -m32" CXX="g++ -m32" AR="ar rc" RANLIB="ranlib" make -j4
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-binary
-          path: jk_botti_mm_i386.so
-
-  build-linux-bionic:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build in Ubuntu 18.04 i386 container
-        run: |
-          docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace \
-            lpenz/ubuntu-bionic-i386 \
-            bash -c "apt-get -y update && apt-get -y install build-essential g++ make && make -j4"
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-bionic-binary
-          path: jk_botti_mm_i386.so
-
-  build-windows:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install packages
-        run: sudo apt-get -y update && sudo apt-get -y install gcc-mingw-w64 g++-mingw-w64
-      - name: Build
-        run: make -j4 OSTYPE=win32
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-binary
-          path: jk_botti_mm.dll
+  build:
+    uses: ./.github/workflows/build.yml
 
   package:
-    needs: [test, build-linux, build-linux-bionic, build-windows]
+    needs: [test, build]
     uses: ./.github/workflows/package.yml
     with:
       version: snapshot

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,6 +34,28 @@ jobs:
           name: jk_botti-${{ inputs.version }}-linux_ubuntu2404
           path: jk_botti-${{ inputs.version }}-linux_ubuntu2404.tar.xz
 
+  package-linux-bionic:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Linux Bionic binary
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-bionic-binary
+          path: staging
+      - name: Prepare release directory
+        run: |
+          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
+          cp staging/jk_botti_mm_i386.so addons/jk_botti/dlls/
+          ln -sf jk_botti_mm_i386.so addons/jk_botti/dlls/jk_botti_mm.so
+      - name: Create release archive
+        run: tar c addons | xz > jk_botti-${{ inputs.version }}-linux_ubuntu1804.tar.xz
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jk_botti-${{ inputs.version }}-linux_ubuntu1804
+          path: jk_botti-${{ inputs.version }}-linux_ubuntu1804.tar.xz
+
   package-windows:
     runs-on: ubuntu-24.04
     steps:
@@ -57,7 +79,7 @@ jobs:
 
   create-release:
     if: ${{ inputs.create_release }}
-    needs: [package-linux, package-windows]
+    needs: [package-linux, package-linux-bionic, package-windows]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -66,6 +88,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: jk_botti-${{ inputs.version }}-linux_ubuntu2404
+      - name: Download Linux Bionic archive
+        uses: actions/download-artifact@v4
+        with:
+          name: jk_botti-${{ inputs.version }}-linux_ubuntu1804
       - name: Download Windows archive
         uses: actions/download-artifact@v4
         with:
@@ -75,4 +101,5 @@ jobs:
         with:
           files: |
             jk_botti-${{ inputs.version }}-linux_ubuntu2404.tar.xz
+            jk_botti-${{ inputs.version }}-linux_ubuntu1804.tar.xz
             jk_botti-${{ inputs.version }}-win32.tar.xz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,22 @@ jobs:
           name: linux-binary
           path: jk_botti_mm_i386.so
 
+  build-linux-bionic:
+    needs: validate-tag
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build in Ubuntu 18.04 i386 container
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace \
+            lpenz/ubuntu-bionic-i386 \
+            bash -c "apt-get -y update && apt-get -y install build-essential g++ make && make -j4 VER_MAJOR=${{ needs.validate-tag.outputs.ver_major }} VER_MINOR=${{ needs.validate-tag.outputs.ver_minor }} VER_NOTE=${{ needs.validate-tag.outputs.ver_note }}"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-bionic-binary
+          path: jk_botti_mm_i386.so
+
   build-windows:
     needs: validate-tag
     runs-on: ubuntu-24.04
@@ -61,7 +77,7 @@ jobs:
           path: jk_botti_mm.dll
 
   package:
-    needs: [validate-tag, build-linux, build-windows]
+    needs: [validate-tag, build-linux, build-linux-bionic, build-windows]
     uses: ./.github/workflows/package.yml
     with:
       version: ${{ needs.validate-tag.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,56 +28,16 @@ jobs:
             exit 1
           fi
 
-  build-linux:
+  build:
     needs: validate-tag
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Update package list for i386
-        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
-      - name: Install packages
-        run: sudo apt-get -y install build-essential g++-multilib
-      - name: Build
-        run: CC="gcc -m32" CXX="g++ -m32" AR="ar rc" RANLIB="ranlib" make -j4 VER_MAJOR=${{ needs.validate-tag.outputs.ver_major }} VER_MINOR=${{ needs.validate-tag.outputs.ver_minor }} VER_NOTE=${{ needs.validate-tag.outputs.ver_note }}
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-binary
-          path: jk_botti_mm_i386.so
-
-  build-linux-bionic:
-    needs: validate-tag
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build in Ubuntu 18.04 i386 container
-        run: |
-          docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace \
-            lpenz/ubuntu-bionic-i386 \
-            bash -c "apt-get -y update && apt-get -y install build-essential g++ make && make -j4 VER_MAJOR=${{ needs.validate-tag.outputs.ver_major }} VER_MINOR=${{ needs.validate-tag.outputs.ver_minor }} VER_NOTE=${{ needs.validate-tag.outputs.ver_note }}"
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: linux-bionic-binary
-          path: jk_botti_mm_i386.so
-
-  build-windows:
-    needs: validate-tag
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install packages
-        run: sudo apt-get -y update && sudo apt-get -y install gcc-mingw-w64 g++-mingw-w64
-      - name: Build
-        run: make -j4 OSTYPE=win32 VER_MAJOR=${{ needs.validate-tag.outputs.ver_major }} VER_MINOR=${{ needs.validate-tag.outputs.ver_minor }} VER_NOTE=${{ needs.validate-tag.outputs.ver_note }}
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-binary
-          path: jk_botti_mm.dll
+    uses: ./.github/workflows/build.yml
+    with:
+      ver_major: ${{ needs.validate-tag.outputs.ver_major }}
+      ver_minor: ${{ needs.validate-tag.outputs.ver_minor }}
+      ver_note: ${{ needs.validate-tag.outputs.ver_note }}
 
   package:
-    needs: [validate-tag, build-linux, build-linux-bionic, build-windows]
+    needs: [validate-tag, build]
     uses: ./.github/workflows/package.yml
     with:
       version: ${{ needs.validate-tag.outputs.version }}


### PR DESCRIPTION
## Summary
- Add `build-linux-bionic` job using `lpenz/ubuntu-bionic-i386` Docker image to produce a binary compatible with older glibc (Debian 10/11, Ubuntu 18.04+) (#96)
- New release archive: `jk_botti-<version>-linux_ubuntu1804.tar.xz`
- Uses `docker run` with workspace mount (i386 container can't run x86_64 GitHub Actions natively)
- Extract shared `build.yml` reusable workflow called by both `ci.yml` and `release.yml`, so CI exercises the same build configuration as actual releases

## Test plan
- [x] All CI jobs pass (build, build-bionic, build-windows, test, coverage, packaging)
- [x] `package / package-linux-bionic` produces archive artifact
- [ ] Binary from bionic build loads on older Linux servers (Debian 11)