### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update package list for i386
         run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
       - name: Install packages
@@ -33,7 +33,7 @@ jobs:
           fi
           CC="gcc -m32" CXX="g++ -m32" AR="ar rc" RANLIB="ranlib" make -j4 $VERFLAGS
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-binary
           path: jk_botti_mm_i386.so
@@ -41,7 +41,7 @@ jobs:
   build-linux-bionic:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build in Ubuntu 18.04 i386 container
         run: |
           VERFLAGS=""
@@ -52,7 +52,7 @@ jobs:
             lpenz/ubuntu-bionic-i386 \
             bash -c "apt-get -y update && apt-get -y install build-essential g++ make && make -j4 $VERFLAGS"
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-bionic-binary
           path: jk_botti_mm_i386.so
@@ -60,7 +60,7 @@ jobs:
   build-windows:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install packages
         run: sudo apt-get -y update && sudo apt-get -y install gcc-mingw-w64 g++-mingw-w64
       - name: Build
@@ -71,7 +71,7 @@ jobs:
           fi
           make -j4 OSTYPE=win32 $VERFLAGS
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-binary
           path: jk_botti_mm.dll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update package list for i386
         run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
       - name: Install packages
@@ -24,7 +24,7 @@ jobs:
   coverage:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update package list for i386
         run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
       - name: Install packages
@@ -48,7 +48,7 @@ jobs:
             echo "$branches"
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: tests/coverage_report

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,9 +15,9 @@ jobs:
   package-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download Linux binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-binary
           path: staging
@@ -29,7 +29,7 @@ jobs:
       - name: Create release archive
         run: tar c addons | xz > jk_botti-${{ inputs.version }}-linux_ubuntu2404.tar.xz
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jk_botti-${{ inputs.version }}-linux_ubuntu2404
           path: jk_botti-${{ inputs.version }}-linux_ubuntu2404.tar.xz
@@ -37,9 +37,9 @@ jobs:
   package-linux-bionic:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download Linux Bionic binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-bionic-binary
           path: staging
@@ -51,7 +51,7 @@ jobs:
       - name: Create release archive
         run: tar c addons | xz > jk_botti-${{ inputs.version }}-linux_ubuntu1804.tar.xz
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jk_botti-${{ inputs.version }}-linux_ubuntu1804
           path: jk_botti-${{ inputs.version }}-linux_ubuntu1804.tar.xz
@@ -59,9 +59,9 @@ jobs:
   package-windows:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download Windows binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: windows-binary
           path: staging
@@ -72,7 +72,7 @@ jobs:
       - name: Create release archive
         run: tar c addons | xz > jk_botti-${{ inputs.version }}-win32.tar.xz
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jk_botti-${{ inputs.version }}-win32
           path: jk_botti-${{ inputs.version }}-win32.tar.xz
@@ -85,15 +85,15 @@ jobs:
       contents: write
     steps:
       - name: Download Linux archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jk_botti-${{ inputs.version }}-linux_ubuntu2404
       - name: Download Linux Bionic archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jk_botti-${{ inputs.version }}-linux_ubuntu1804
       - name: Download Windows archive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jk_botti-${{ inputs.version }}-win32
       - name: Create GitHub release


### PR DESCRIPTION
## Summary
- Update `actions/checkout` v4 -> v6
- Update `actions/upload-artifact` v4 -> v7
- Update `actions/download-artifact` v4 -> v8

Fixes Node.js 20 deprecation warnings (Node.js 24 becomes default June 2, 2026).

## Test plan
- [ ] All CI jobs pass without Node.js deprecation warnings