### PR TITLE
Add set_team command for custom team model mapping

### DIFF
--- a/addons/jk_botti/jk_botti.cfg
+++ b/addons/jk_botti/jk_botti.cfg
@@ -123,6 +123,13 @@ team_balancetype 1
 # block bots joining these team by autobalancing:
 #team_blockedlist "scientist;gman"
 
+# Custom team model mapping for mods that use multiple player models per team.
+# Maps model names to team names so bots correctly identify teammates.
+# Models not listed fall back to using model name as team (default HL1 behavior).
+# Example:
+#set_team team1 "gign;sas;gsg9"
+#set_team team2 "arctic;terror;leet"
+
 # Remove the comments on the 2 lines below to support a minimum and maximum
 # number of bots running on a dedicated server.  Bots will be added to the
 # server until the total number of players (bots and humans) reaches the

--- a/addons/jk_botti/jk_botti_readme.txt
+++ b/addons/jk_botti/jk_botti_readme.txt
@@ -407,6 +407,34 @@ addons/jk_botti/* - config files, readme files
 For commands 'bot_skill_setup' and 'botweapon' see below.
 For other commands see jk_botti.cfg
 
+Command - set_team
+
+Usage:
+ - set_team <teamname> "model1;model2;..."
+      Map player models to a team name. Bots will treat all players using
+      any of the listed models as members of the same team. Models not
+      listed in any set_team command use the default HL1 behavior (model
+      name = team name).
+
+ - set_team clear
+      Remove all custom team model mappings.
+
+ - set_team
+      Show number of active model mappings.
+
+Example:
+ In jk_botti.cfg:
+   set_team team1 "gign;sas;gsg9"
+   set_team team2 "arctic;terror;leet"
+
+ With this config, a bot using the "gign" model will recognize players
+ using "sas" or "gsg9" models as teammates, and treat "arctic", "terror",
+ and "leet" players as enemies. Players using models not listed (e.g.
+ "scientist") are treated as their own team.
+
+ This is useful for custom mods that assign multiple player
+ models to the same team.
+
 Command - bot_shoot_breakables
 
 Usage:

--- a/commands.cpp
+++ b/commands.cpp
@@ -653,6 +653,30 @@ static qboolean ProcessCommand(const int cmdtype, const printfunc_t printfunc, v
       return TRUE;
    }
 
+   else if (FStrEq(pcmd, "set_team"))
+   {
+      if ((arg1 != NULL) && (*arg1 != 0) && (arg2 != NULL) && (*arg2 != 0))
+      {
+         UTIL_SetTeamModelMapping(arg1, arg2);
+         safevoid_snprintf(msg, sizeof(msg), "set_team: mapped models \"%s\" to team \"%s\"\n", arg2, arg1);
+         printfunc(PRINTFUNC_INFO, arg, msg);
+      }
+      else if ((arg1 != NULL) && FStrEq(arg1, "clear"))
+      {
+         UTIL_ClearTeamModelMapping();
+         printfunc(PRINTFUNC_INFO, arg, "set_team: cleared all team model mappings\n");
+      }
+      else
+      {
+         safevoid_snprintf(msg, sizeof(msg), "set_team: %d model mappings active\n", UTIL_GetTeamModelMappingCount());
+         printfunc(PRINTFUNC_INFO, arg, msg);
+         printfunc(PRINTFUNC_INFO, arg, "usage: set_team <teamname> \"model1;model2;...\"\n");
+         printfunc(PRINTFUNC_INFO, arg, "       set_team clear\n");
+      }
+
+      return TRUE;
+   }
+
    else if (FStrEq(pcmd, "botskill"))
    {
       if ((arg1 != NULL) && (*arg1 != 0))

--- a/dll.cpp
+++ b/dll.cpp
@@ -650,6 +650,9 @@ static void StartFrameOpenConfigFile(void)
 
    need_to_open_cfg = FALSE;  // only do this once!!!
 
+   // Clear custom team model mapping before re-reading config
+   UTIL_ClearTeamModelMapping();
+
    // check if jk_botti_mapname.cfg file exists...
    if(stricmp(STRING(gpGlobals->mapname), "logo") == 0)
       safe_strcopy(mapname, sizeof(mapname), "_jk_botti_logo.cfg");

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -1545,6 +1545,112 @@ static int test_get_team(void)
    ASSERT_STR(teamstr, "");
    PASS();
 
+   // --- Custom team model mapping ---
+
+   TEST("no mapping -> model name used as team");
+   UTIL_ClearTeamModelMapping();
+   mock_team_return_val = (char *)"gign";
+   UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+   ASSERT_STR(teamstr, "gign");
+   PASS();
+
+   TEST("set_team maps model to team name");
+   UTIL_ClearTeamModelMapping();
+   UTIL_SetTeamModelMapping("team1", "gign;sas");
+   mock_team_return_val = (char *)"gign";
+   UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+   ASSERT_STR(teamstr, "team1");
+   PASS();
+
+   TEST("set_team second model in list");
+   mock_team_return_val = (char *)"sas";
+   UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+   ASSERT_STR(teamstr, "team1");
+   PASS();
+
+   TEST("unmapped model falls through");
+   mock_team_return_val = (char *)"scientist";
+   UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+   ASSERT_STR(teamstr, "scientist");
+   PASS();
+
+   TEST("multiple teams");
+   UTIL_SetTeamModelMapping("team2", "arctic;terror");
+   mock_team_return_val = (char *)"arctic";
+   UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+   ASSERT_STR(teamstr, "team2");
+   PASS();
+
+   TEST("team1 still works after adding team2");
+   mock_team_return_val = (char *)"sas";
+   UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+   ASSERT_STR(teamstr, "team1");
+   PASS();
+
+   TEST("case-insensitive model lookup");
+   mock_team_return_val = (char *)"GIGN";
+   UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+   ASSERT_STR(teamstr, "team1");
+   PASS();
+
+   TEST("whitespace around model names is trimmed");
+   UTIL_ClearTeamModelMapping();
+   UTIL_SetTeamModelMapping("team1", " gign ; sas ");
+   mock_team_return_val = (char *)"gign";
+   UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+   ASSERT_STR(teamstr, "team1");
+   mock_team_return_val = (char *)"sas";
+   UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+   ASSERT_STR(teamstr, "team1");
+   PASS();
+
+   TEST("overwrite existing model mapping");
+   UTIL_SetTeamModelMapping("team2", "gign");
+   mock_team_return_val = (char *)"gign";
+   UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+   ASSERT_STR(teamstr, "team2");
+   PASS();
+
+   TEST("clear removes all mappings");
+   UTIL_ClearTeamModelMapping();
+   ASSERT_INT(UTIL_GetTeamModelMappingCount(), 0);
+   mock_team_return_val = (char *)"gign";
+   UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+   ASSERT_STR(teamstr, "gign");
+   PASS();
+
+   TEST("mapping count");
+   UTIL_ClearTeamModelMapping();
+   UTIL_SetTeamModelMapping("red", "gign;sas;gsg9");
+   ASSERT_INT(UTIL_GetTeamModelMappingCount(), 3);
+   UTIL_SetTeamModelMapping("blue", "arctic;terror");
+   ASSERT_INT(UTIL_GetTeamModelMappingCount(), 5);
+   PASS();
+
+   TEST("table full -> extra entries ignored");
+   UTIL_ClearTeamModelMapping();
+   {
+      char model[16];
+      for (int i = 0; i < 64; i++)
+      {
+         safevoid_snprintf(model, sizeof(model), "mdl%d", i);
+         UTIL_SetTeamModelMapping("full", model);
+      }
+      ASSERT_INT(UTIL_GetTeamModelMappingCount(), 64);
+      // 65th entry should be rejected
+      UTIL_SetTeamModelMapping("full", "overflow");
+      ASSERT_INT(UTIL_GetTeamModelMappingCount(), 64);
+      // overwriting existing entry should still work at capacity
+      UTIL_SetTeamModelMapping("replaced", "mdl0");
+      ASSERT_INT(UTIL_GetTeamModelMappingCount(), 64);
+      mock_team_return_val = (char *)"mdl0";
+      UTIL_GetTeam(p, teamstr, sizeof(teamstr));
+      ASSERT_STR(teamstr, "replaced");
+   }
+   PASS();
+
+   UTIL_ClearTeamModelMapping();
+
    return 0;
 }
 

--- a/util.cpp
+++ b/util.cpp
@@ -24,6 +24,20 @@ extern qboolean is_team_play;
 static breakable_list_t *g_breakable_list = NULL;
 static breakable_list_t breakable_list_memarray[BREAKABLE_LIST_MAX];
 
+// Custom team model mapping: maps model names to team names.
+// Configured via "set_team <teamname> model1;model2;..." in jk_botti.cfg.
+// Models not in the table fall through to using model name as team name.
+#define MAX_TEAM_MODEL_ENTRIES 64
+
+struct team_model_entry_t
+{
+   char model[MAX_TEAMNAME_LENGTH];
+   char team[MAX_TEAMNAME_LENGTH];
+};
+
+static team_model_entry_t team_model_map[MAX_TEAM_MODEL_ENTRIES];
+static int team_model_map_count = 0;
+
 // Polynomial sincos using only SSE-friendly operations. Avoids x87/SSE
 // register transition penalty. Uses Cephes-style range reduction to
 // [-pi/4, pi/4] and minimax polynomials. Max error vs libm: < 2e-16.
@@ -934,11 +948,87 @@ edict_t *DBG_EntOfVars( const entvars_t *pev )
 }
 #endif //DEBUG
 
-// return team string 0 through 3 based what MOD uses for team numbers
+void UTIL_SetTeamModelMapping(const char *teamname, const char *model_list)
+{
+   // Parse semicolon-separated model list, add each as a mapping entry.
+   // Duplicate team+model pairs are ignored. Existing mappings for a model
+   // are overwritten.
+   int slen = strlen(model_list);
+   if (slen > 4096)
+      slen = 4096;
+   char *buf = (char *)alloca(slen + 1);
+   memcpy(buf, model_list, slen);
+   buf[slen] = '\0';
+
+   char *model = strtok(buf, ";");
+   while (model != NULL && *model)
+   {
+      // Strip leading and trailing whitespace
+      while (*model == ' ')
+         model++;
+      char *end = model + strlen(model) - 1;
+      while (end > model && *end == ' ')
+         *end-- = '\0';
+
+      if (*model)
+      {
+         // Check if this model already has a mapping, overwrite it
+         int idx = -1;
+         for (int i = 0; i < team_model_map_count; i++)
+         {
+            if (!stricmp(team_model_map[i].model, model))
+            {
+               idx = i;
+               break;
+            }
+         }
+         if (idx < 0)
+         {
+            if (team_model_map_count >= MAX_TEAM_MODEL_ENTRIES)
+            {
+               UTIL_ConsolePrintf("set_team: table full (%d entries), ignoring model \"%s\"\n",
+                  MAX_TEAM_MODEL_ENTRIES, model);
+               model = strtok(NULL, ";");
+               continue;
+            }
+            idx = team_model_map_count++;
+         }
+
+         safe_strcopy(team_model_map[idx].model, sizeof(team_model_map[idx].model), model);
+         safe_strcopy(team_model_map[idx].team, sizeof(team_model_map[idx].team), teamname);
+      }
+
+      model = strtok(NULL, ";");
+   }
+}
+
+void UTIL_ClearTeamModelMapping(void)
+{
+   team_model_map_count = 0;
+}
+
+int UTIL_GetTeamModelMappingCount(void)
+{
+   return team_model_map_count;
+}
+
+// return team string based on custom model mapping or model name (default HL1)
 char * UTIL_GetTeam(edict_t *pEntity, char *teamstr, size_t slen)
 {
-   safe_strcopy(teamstr, slen, INFOKEY_VALUE(GET_INFOKEYBUFFER(pEntity), "model"));
+   const char *model = INFOKEY_VALUE(GET_INFOKEYBUFFER(pEntity), "model");
 
+   // Look up model in custom team mapping
+   for (int i = 0; i < team_model_map_count; i++)
+   {
+      if (!stricmp(team_model_map[i].model, model))
+      {
+         safe_strcopy(teamstr, slen, team_model_map[i].team);
+         return(teamstr);
+      }
+   }
+
+   // No mapping found, use model name as team (default HL1 behavior)
+   safe_strcopy(teamstr, slen, model);
    return(teamstr);
 }
 

--- a/util.h
+++ b/util.h
@@ -36,6 +36,9 @@ float RANDOM_FLOAT2(float flLow, float flHigh);
 void ClientPrint( edict_t *pEdict, int msg_dest, const char *msg_name);
 void UTIL_HostSay( edict_t *pEntity, int teamonly, char *message );
 char* UTIL_GetTeam(edict_t *pEntity, char *teamstr, size_t slen);
+void UTIL_SetTeamModelMapping(const char *teamname, const char *model_list);
+void UTIL_ClearTeamModelMapping(void);
+int UTIL_GetTeamModelMappingCount(void);
 
 qboolean FInShootCone( const Vector & Origin, edict_t *pEdict, float distance, float target_radius, float min_angle);
 qboolean FVisible( const Vector &vecOrigin, edict_t *pEdict, edict_t ** pHit);


### PR DESCRIPTION
## Summary
- Add `set_team` config/server command that maps player model names to team names (#100)
- Fixes bots attacking teammates when mods (e.g. AMX Mod X) use multiple models per team
- Models not in any mapping fall back to default HL1 behavior (model name = team name)

## Usage
```
set_team team1 "gign;sas;gsg9"
set_team team2 "arctic;terror;leet"
set_team clear
```

## Implementation
- Model-to-team lookup table in `util.cpp` (max 64 entries)
- `UTIL_GetTeam()` checks mapping first, falls through to model name
- Mapping cleared on map change before config re-read
- Case-insensitive model matching

## Test plan
- [x] 10 new unit tests (mapping, fallthrough, case-insensitive, overwrite, clear, count)
- [x] All existing tests pass
- [x] Linux and Win32 builds
- [x] CI passes
- [ ] Feedback from issue reporter on whether this solves their use case