### PR TITLE
Add CPUID-dispatching shim for automatic variant selection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,24 +25,28 @@ jobs:
         run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
       - name: Install packages
         run: sudo apt-get -y install build-essential g++-multilib
-      - name: Build
+      - name: Build variants (shim + x87 + SSE3 + AVX2FMA)
         run: |
           VERFLAGS=""
           if [ -n "${{ inputs.ver_major }}" ]; then
             VERFLAGS="VER_MAJOR=${{ inputs.ver_major }} VER_MINOR=${{ inputs.ver_minor }} VER_NOTE=${{ inputs.ver_note }}"
           fi
-          CC="gcc -m32" CXX="g++ -m32" AR="ar rc" RANLIB="ranlib" make -j4 $VERFLAGS
-      - name: Upload artifact
+          CC="gcc -m32" CXX="g++ -m32" AR="ar rc" RANLIB="ranlib" make -j4 variants $VERFLAGS
+      - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: linux-binary
-          path: jk_botti_mm_i386.so
+          name: linux-binaries
+          path: |
+            jk_botti_mm_i386.so
+            jk_botti_mm_x87_i386.so
+            jk_botti_mm_sse3_i386.so
+            jk_botti_mm_avx2fma_i386.so
 
   build-linux-bionic:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Build in Ubuntu 18.04 i386 container
+      - name: Build variants in Ubuntu 18.04 i386 container
         run: |
           VERFLAGS=""
           if [ -n "${{ inputs.ver_major }}" ]; then
@@ -50,12 +54,16 @@ jobs:
           fi
           docker run --rm -v "${{ github.workspace }}:/workspace" -w /workspace \
             lpenz/ubuntu-bionic-i386 \
-            bash -c "apt-get -y update && apt-get -y install build-essential g++ make && make -j4 TARGETFLAGS='-march=i686 -mtune=generic -msse3 -mfpmath=sse' $VERFLAGS"
-      - name: Upload artifact
+            bash -c "apt-get -y update && apt-get -y install build-essential g++ make && make -j4 variants $VERFLAGS"
+      - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: linux-bionic-binary
-          path: jk_botti_mm_i386.so
+          name: linux-bionic-binaries
+          path: |
+            jk_botti_mm_i386.so
+            jk_botti_mm_x87_i386.so
+            jk_botti_mm_sse3_i386.so
+            jk_botti_mm_avx2fma_i386.so
 
   build-windows:
     runs-on: ubuntu-24.04
@@ -63,34 +71,19 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install packages
         run: sudo apt-get -y update && sudo apt-get -y install gcc-mingw-w64 g++-mingw-w64
-      - name: Build
+      - name: Build variants (shim + x87 + SSE3 + AVX2FMA)
         run: |
           VERFLAGS=""
           if [ -n "${{ inputs.ver_major }}" ]; then
             VERFLAGS="VER_MAJOR=${{ inputs.ver_major }} VER_MINOR=${{ inputs.ver_minor }} VER_NOTE=${{ inputs.ver_note }}"
           fi
-          make -j4 OSTYPE=win32 $VERFLAGS
-      - name: Upload artifact
+          make -j4 OSTYPE=win32 variants $VERFLAGS
+      - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: windows-binary
-          path: jk_botti_mm.dll
-
-  build-windows-sse:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-      - name: Install packages
-        run: sudo apt-get -y update && sudo apt-get -y install gcc-mingw-w64 g++-mingw-w64
-      - name: Build
-        run: |
-          VERFLAGS=""
-          if [ -n "${{ inputs.ver_major }}" ]; then
-            VERFLAGS="VER_MAJOR=${{ inputs.ver_major }} VER_MINOR=${{ inputs.ver_minor }} VER_NOTE=${{ inputs.ver_note }}"
-          fi
-          make -j4 OSTYPE=win32 TARGETFLAGS='-march=i686 -mtune=generic -msse3 -mfpmath=sse' $VERFLAGS
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: windows-sse-binary
-          path: jk_botti_mm.dll
+          name: windows-binaries
+          path: |
+            jk_botti_mm.dll
+            jk_botti_mm_x87.dll
+            jk_botti_mm_sse3.dll
+            jk_botti_mm_avx2fma.dll

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,91 +16,79 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Download Linux binary
+      - name: Download Linux binaries
         uses: actions/download-artifact@v8
         with:
-          name: linux-binary
+          name: linux-binaries
           path: staging
       - name: Prepare release directory
         run: |
           rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
           cp staging/jk_botti_mm_i386.so addons/jk_botti/dlls/
+          cp staging/jk_botti_mm_x87_i386.so addons/jk_botti/dlls/
+          cp staging/jk_botti_mm_sse3_i386.so addons/jk_botti/dlls/
+          cp staging/jk_botti_mm_avx2fma_i386.so addons/jk_botti/dlls/
           ln -sf jk_botti_mm_i386.so addons/jk_botti/dlls/jk_botti_mm.so
       - name: Create release archive
-        run: tar c addons | xz > jk_botti-${{ inputs.version }}-linux_ubuntu2404_avx2fma.tar.xz
+        run: tar c addons | xz > jk_botti-${{ inputs.version }}-linux_ubuntu2404.tar.xz
       - name: Upload release artifact
         uses: actions/upload-artifact@v7
         with:
-          name: jk_botti-${{ inputs.version }}-linux_ubuntu2404_avx2fma
-          path: jk_botti-${{ inputs.version }}-linux_ubuntu2404_avx2fma.tar.xz
+          name: jk_botti-${{ inputs.version }}-linux_ubuntu2404
+          path: jk_botti-${{ inputs.version }}-linux_ubuntu2404.tar.xz
 
   package-linux-bionic:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Download Linux Bionic binary
+      - name: Download Linux Bionic binaries
         uses: actions/download-artifact@v8
         with:
-          name: linux-bionic-binary
+          name: linux-bionic-binaries
           path: staging
       - name: Prepare release directory
         run: |
           rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
           cp staging/jk_botti_mm_i386.so addons/jk_botti/dlls/
+          cp staging/jk_botti_mm_x87_i386.so addons/jk_botti/dlls/
+          cp staging/jk_botti_mm_sse3_i386.so addons/jk_botti/dlls/
+          cp staging/jk_botti_mm_avx2fma_i386.so addons/jk_botti/dlls/
           ln -sf jk_botti_mm_i386.so addons/jk_botti/dlls/jk_botti_mm.so
       - name: Create release archive
-        run: tar c addons | xz > jk_botti-${{ inputs.version }}-linux_ubuntu1804_sse.tar.xz
+        run: tar c addons | xz > jk_botti-${{ inputs.version }}-linux_ubuntu1804.tar.xz
       - name: Upload release artifact
         uses: actions/upload-artifact@v7
         with:
-          name: jk_botti-${{ inputs.version }}-linux_ubuntu1804_sse
-          path: jk_botti-${{ inputs.version }}-linux_ubuntu1804_sse.tar.xz
+          name: jk_botti-${{ inputs.version }}-linux_ubuntu1804
+          path: jk_botti-${{ inputs.version }}-linux_ubuntu1804.tar.xz
 
   package-windows:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - name: Download Windows binary
+      - name: Download Windows binaries
         uses: actions/download-artifact@v8
         with:
-          name: windows-binary
+          name: windows-binaries
           path: staging
       - name: Prepare release directory
         run: |
           rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
           cp staging/jk_botti_mm.dll addons/jk_botti/dlls/
+          cp staging/jk_botti_mm_x87.dll addons/jk_botti/dlls/
+          cp staging/jk_botti_mm_sse3.dll addons/jk_botti/dlls/
+          cp staging/jk_botti_mm_avx2fma.dll addons/jk_botti/dlls/
       - name: Create release archive
-        run: tar c addons | xz > jk_botti-${{ inputs.version }}-win32_avx2fma.tar.xz
+        run: tar c addons | xz > jk_botti-${{ inputs.version }}-win32.tar.xz
       - name: Upload release artifact
         uses: actions/upload-artifact@v7
         with:
-          name: jk_botti-${{ inputs.version }}-win32_avx2fma
-          path: jk_botti-${{ inputs.version }}-win32_avx2fma.tar.xz
-
-  package-windows-sse:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-      - name: Download Windows SSE binary
-        uses: actions/download-artifact@v8
-        with:
-          name: windows-sse-binary
-          path: staging
-      - name: Prepare release directory
-        run: |
-          rm -rf addons/jk_botti/dlls && mkdir addons/jk_botti/dlls
-          cp staging/jk_botti_mm.dll addons/jk_botti/dlls/
-      - name: Create release archive
-        run: tar c addons | xz > jk_botti-${{ inputs.version }}-win32_sse.tar.xz
-      - name: Upload release artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: jk_botti-${{ inputs.version }}-win32_sse
-          path: jk_botti-${{ inputs.version }}-win32_sse.tar.xz
+          name: jk_botti-${{ inputs.version }}-win32
+          path: jk_botti-${{ inputs.version }}-win32.tar.xz
 
   create-release:
     if: ${{ inputs.create_release }}
-    needs: [package-linux, package-linux-bionic, package-windows, package-windows-sse]
+    needs: [package-linux, package-linux-bionic, package-windows]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -108,24 +96,19 @@ jobs:
       - name: Download Linux archive
         uses: actions/download-artifact@v8
         with:
-          name: jk_botti-${{ inputs.version }}-linux_ubuntu2404_avx2fma
+          name: jk_botti-${{ inputs.version }}-linux_ubuntu2404
       - name: Download Linux Bionic archive
         uses: actions/download-artifact@v8
         with:
-          name: jk_botti-${{ inputs.version }}-linux_ubuntu1804_sse
+          name: jk_botti-${{ inputs.version }}-linux_ubuntu1804
       - name: Download Windows archive
         uses: actions/download-artifact@v8
         with:
-          name: jk_botti-${{ inputs.version }}-win32_avx2fma
-      - name: Download Windows SSE archive
-        uses: actions/download-artifact@v8
-        with:
-          name: jk_botti-${{ inputs.version }}-win32_sse
+          name: jk_botti-${{ inputs.version }}-win32
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            jk_botti-${{ inputs.version }}-linux_ubuntu2404_avx2fma.tar.xz
-            jk_botti-${{ inputs.version }}-linux_ubuntu1804_sse.tar.xz
-            jk_botti-${{ inputs.version }}-win32_avx2fma.tar.xz
-            jk_botti-${{ inputs.version }}-win32_sse.tar.xz
+            jk_botti-${{ inputs.version }}-linux_ubuntu2404.tar.xz
+            jk_botti-${{ inputs.version }}-linux_ubuntu1804.tar.xz
+            jk_botti-${{ inputs.version }}-win32.tar.xz

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,21 @@
 ##  for compiling linux: make
 ##  for compiling win32: make OSTYPE=win32
 ##
+## Produces four artifacts per platform:
+##   jk_botti_mm{.dll,_i386.so}           -- shim w/ runtime CPUID dispatch
+##   jk_botti_mm_x87{.dll,_i386.so}       -- i686 / x87 fallback build
+##   jk_botti_mm_sse3{.dll,_i386.so}      -- SSE3 build
+##   jk_botti_mm_avx2fma{.dll,_i386.so}   -- AVX2+FMA build
+##
+## Build one variant only:
+##   make VARIANT=shim
+##   make VARIANT=x87
+##   make VARIANT=sse3
+##   make VARIANT=avx2fma
+##
+## Override per-variant flags via SHIM_TARGETFLAGS / X87_TARGETFLAGS /
+## SSE3_TARGETFLAGS / AVX2FMA_TARGETFLAGS on the command line.
+##
 
 ifeq ($(OSTYPE),win32)
 	CXX = i686-w64-mingw32-g++ -m32
@@ -12,7 +27,7 @@ ifeq ($(OSTYPE),win32)
 	LINKFLAGS = -mdll -lm -lwsock32 -lws2_32 -Xlinker --add-stdcall-alias -g
 	DLLEND = .dll
 	ZLIB_OSFLAGS = -DZ_PREFIX
-	OBJDIR = obj/win32
+	OS_DIR = win32
 else
 	CXX ?= g++ -m32
 	CC ?= gcc -m32
@@ -22,7 +37,7 @@ else
 	LINKFLAGS = -fPIC -shared -ldl -lm -g
 	DLLEND = _i386.so
 	ZLIB_OSFLAGS = -DZ_PREFIX
-	OBJDIR = obj/linux
+	OS_DIR = linux
 endif
 
 # Override make's built-in defaults (origin 'default') which ?= won't catch
@@ -33,23 +48,115 @@ ifeq ($(origin AR),default)
 AR = ar rc
 endif
 
+TARGET = jk_botti_mm
+
+SHIM_TARGETFLAGS    ?= -march=i686 -mtune=generic
+X87_TARGETFLAGS     ?= -march=i686 -mtune=generic
+SSE3_TARGETFLAGS    ?= -march=i686 -mtune=generic -msse3 -mfpmath=sse
+AVX2FMA_TARGETFLAGS ?= -march=i686 -mtune=generic -mavx2 -mfma -mfpmath=sse
+VALGRIND_TARGETFLAGS ?= $(SSE3_TARGETFLAGS)
+
+SHIM_OUT := $(TARGET)$(DLLEND)
+X87_OUT  := $(TARGET)_x87$(DLLEND)
+SSE3_OUT := $(TARGET)_sse3$(DLLEND)
+AVX_OUT  := $(TARGET)_avx2fma$(DLLEND)
+
+ifeq ($(VARIANT),)
+# ============================================================================
+# Top-level: dispatch variant builds via recursive make.
+# ============================================================================
+
+.PHONY: all variants shim x87 sse3 avx2fma test valgrind coverage clean distclean depend
+
+all: variants
+
+variants: shim x87 sse3 avx2fma
+
+shim:
+	+$(MAKE) VARIANT=shim _build
+
+x87:
+	+$(MAKE) VARIANT=x87 _build
+
+sse3:
+	+$(MAKE) VARIANT=sse3 _build
+
+avx2fma:
+	+$(MAKE) VARIANT=avx2fma _build
+
+test:
+	+$(MAKE) VARIANT=avx2fma _test
+
+valgrind:
+	$(MAKE) -C tests clean
+	+$(MAKE) VARIANT=sse3 TARGETFLAGS_OVERRIDE="$(VALGRIND_TARGETFLAGS)" _valgrind
+
+coverage:
+	+$(MAKE) VARIANT=avx2fma _coverage
+
+depend:
+	+$(MAKE) VARIANT=avx2fma _depend
+
+clean:
+	rm -rf obj
+	rm -f $(SHIM_OUT) $(X87_OUT) $(SSE3_OUT) $(AVX_OUT)
+	$(MAKE) -C tests clean
+
+distclean:
+	rm -rf obj
+	rm -f $(SHIM_OUT) $(X87_OUT) $(SSE3_OUT) $(AVX_OUT)
+	rm -f $(TARGET).dll $(TARGET)_x87.dll $(TARGET)_sse3.dll $(TARGET)_avx2fma.dll
+	rm -f $(TARGET)_i386.so $(TARGET)_x87_i386.so $(TARGET)_sse3_i386.so $(TARGET)_avx2fma_i386.so
+	rm -rf addons/jk_botti/dlls/*
+
+else
+# ============================================================================
+# Variant build (VARIANT is set).
+# ============================================================================
+
+ifeq ($(VARIANT),shim)
+	TARGETFLAGS := $(SHIM_TARGETFLAGS)
+	VARIANT_SUFFIX :=
+else ifeq ($(VARIANT),x87)
+	TARGETFLAGS := $(X87_TARGETFLAGS)
+	VARIANT_SUFFIX := _x87
+else ifeq ($(VARIANT),sse3)
+	TARGETFLAGS := $(SSE3_TARGETFLAGS)
+	VARIANT_SUFFIX := _sse3
+else ifeq ($(VARIANT),avx2fma)
+	TARGETFLAGS := $(AVX2FMA_TARGETFLAGS)
+	VARIANT_SUFFIX := _avx2fma
+else
+	$(error Unknown VARIANT=$(VARIANT) (valid: shim, x87, sse3, avx2fma))
+endif
+
+# Expose the variant tag to the C++ code (Plugin_info.version string).
+ifneq ($(VARIANT_SUFFIX),)
+	VERFLAGS_EXTRA = -DVARIANT_VERSION_SUFFIX=\"$(VARIANT_SUFFIX)\"
+endif
+
+# Allow top-level targets (e.g. valgrind) to force alternate flags.
+ifneq ($(TARGETFLAGS_OVERRIDE),)
+	TARGETFLAGS := $(TARGETFLAGS_OVERRIDE)
+endif
+
+OBJDIR := obj/$(OS_DIR)-$(VARIANT)
+OUTPUT := $(TARGET)$(VARIANT_SUFFIX)$(DLLEND)
+
 VER_MAJOR ?= 0
 VER_MINOR ?= 0
-VER_NOTE ?= git$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+VER_NOTE  ?= git$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+VERFLAGS   = -DVER_MAJOR=$(VER_MAJOR) -DVER_MINOR=$(VER_MINOR) -DVER_NOTE=\"$(VER_NOTE)\" $(VERFLAGS_EXTRA)
 
-VERFLAGS = -DVER_MAJOR=$(VER_MAJOR) -DVER_MINOR=$(VER_MINOR) -DVER_NOTE=\"$(VER_NOTE)\"
-
-TARGET = jk_botti_mm
-BASEFLAGS = -Wall -Wno-write-strings -Wno-class-memaccess ${VERFLAGS}
+BASEFLAGS  = -Wall -Wno-write-strings -Wno-class-memaccess $(VERFLAGS)
 BASEFLAGS += -fno-strict-aliasing -fno-strict-overflow
 BASEFLAGS += -fvisibility=hidden -mincoming-stack-boundary=2
-TARGETFLAGS ?= -march=i686 -mtune=generic -mavx2 -mfma -mfpmath=sse
-ARCHFLAG += $(TARGETFLAGS)
+ARCHFLAG  += $(TARGETFLAGS)
 
 ifeq ($(DBG_FLGS),1)
 	OPTFLAGS = -O0 -g
 else
-	OPTFLAGS = -O2 -fomit-frame-pointer -g
+	OPTFLAGS  = -O2 -fomit-frame-pointer -g
 	OPTFLAGS += -fno-semantic-interposition
 endif
 
@@ -59,9 +166,36 @@ INCLUDES = -I"./metamod" \
 	-I"./engine" \
 	-I"./pm_shared"
 
-CFLAGS = ${BASEFLAGS} ${OPTFLAGS} ${ARCHFLAG} ${INCLUDES}
-CXXFLAGS = -fno-rtti -fno-exceptions
-CXXFLAGS += ${CFLAGS}
+CFLAGS    = $(BASEFLAGS) $(OPTFLAGS) $(ARCHFLAG) $(INCLUDES)
+CXXFLAGS  = -fno-rtti -fno-exceptions
+CXXFLAGS += $(CFLAGS)
+
+.PHONY: _build _test _valgrind _coverage _depend
+
+# ----------------------------------------------------------------------------
+# Shim variant: single-file forwarder, no zlib, no HL SDK headers.
+# ----------------------------------------------------------------------------
+ifeq ($(VARIANT),shim)
+
+SHIM_CFLAGS = -Wall -Wextra -Wno-unused-parameter $(OPTFLAGS) $(ARCHFLAG) -std=gnu99
+
+_build: $(OUTPUT)
+
+$(OUTPUT): shim.c | $(OBJDIR)
+	$(CC) $(SHIM_CFLAGS) -o $@ $< $(LINKFLAGS)
+	mkdir -p addons/jk_botti/dlls
+	cp $@ addons/jk_botti/dlls/
+ifneq ($(OSTYPE),win32)
+	ln -sf $(OUTPUT) addons/jk_botti/dlls/$(TARGET).so
+endif
+
+$(OBJDIR):
+	mkdir -p $@
+
+else
+# ----------------------------------------------------------------------------
+# Full-plugin variants (sse, avx2fma): compile all C++ sources + zlib.
+# ----------------------------------------------------------------------------
 
 SRC = 	bot.cpp \
 	bot_chat.cpp \
@@ -86,45 +220,39 @@ SRC = 	bot.cpp \
 	util.cpp \
 	waypoint.cpp
 
-OBJ = $(SRC:%.cpp=$(OBJDIR)/%.o)
+OBJ      = $(SRC:%.cpp=$(OBJDIR)/%.o)
 ZLIB_LIB = $(OBJDIR)/zlib/libz.a
+DEP_FILE = $(OBJDIR)/Rules.depend
 
-${TARGET}${DLLEND}: $(ZLIB_LIB) ${OBJ}
-	${CC} -o $@ ${OBJ} $(ZLIB_LIB) ${LINKFLAGS}
+_build: $(OUTPUT)
+
+$(OUTPUT): $(ZLIB_LIB) $(OBJ)
+	$(CC) -o $@ $(OBJ) $(ZLIB_LIB) $(LINKFLAGS)
+	mkdir -p addons/jk_botti/dlls
 	cp $@ addons/jk_botti/dlls/
-ifneq ($(OSTYPE),win32)
-	ln -sf ${TARGET}${DLLEND} addons/jk_botti/dlls/${TARGET}.so
-endif
 
 $(ZLIB_LIB): | $(OBJDIR)/zlib
-	(cd $(OBJDIR)/zlib; AR="${AR}" ARFLAGS="" RANLIB="${RANLIB}" CC="${CC} ${OPTFLAGS} ${ARCHFLAG} ${ZLIB_OSFLAGS}" $(CURDIR)/zlib/configure --static; $(MAKE) libz.a CC="${CC} ${OPTFLAGS} ${ARCHFLAG} ${ZLIB_OSFLAGS}" AR="${AR}" ARFLAGS="" RANLIB="${RANLIB}")
+	(cd $(OBJDIR)/zlib; AR="$(AR)" ARFLAGS="" RANLIB="$(RANLIB)" CC="$(CC) $(OPTFLAGS) $(ARCHFLAG) $(ZLIB_OSFLAGS)" $(CURDIR)/zlib/configure --static; $(MAKE) libz.a CC="$(CC) $(OPTFLAGS) $(ARCHFLAG) $(ZLIB_OSFLAGS)" AR="$(AR)" ARFLAGS="" RANLIB="$(RANLIB)")
 
-test: $(ZLIB_LIB)
+_test: $(ZLIB_LIB)
 	$(MAKE) -C tests CXXFLAGS="$(CXXFLAGS)" ZLIB_LIB="../$(ZLIB_LIB)" run
-
-VALGRIND_TARGETFLAGS ?= -march=i686 -mtune=generic -msse3 -mfpmath=sse
-valgrind:
-	$(MAKE) TARGETFLAGS="$(VALGRIND_TARGETFLAGS)" clean
-	$(MAKE) TARGETFLAGS="$(VALGRIND_TARGETFLAGS)" _valgrind
 
 _valgrind: $(ZLIB_LIB)
 	$(MAKE) -C tests CXXFLAGS="$(CXXFLAGS)" ZLIB_LIB="../$(ZLIB_LIB)" valgrind
 
-coverage: $(ZLIB_LIB)
+_coverage: $(ZLIB_LIB)
 	$(MAKE) -C tests CXXFLAGS="$(CXXFLAGS)" ZLIB_LIB="../$(ZLIB_LIB)" coverage
 
-clean:
-	rm -rf obj ${TARGET}${DLLEND} Rules.depend
-	$(MAKE) -C tests clean
+_depend: $(DEP_FILE)
 
-distclean:
-	rm -rf obj Rules.depend ${TARGET}.dll ${TARGET}_i386.so addons/jk_botti/dlls/*
+$(DEP_FILE): Makefile $(SRC) | $(OBJDIR)
+	$(CXX) -MM $(INCLUDES) $(SRC) | sed 's|^\([^ ]\)|$(OBJDIR)/\1|' > $@
 
 $(OBJDIR)/%.o: %.cpp | $(OBJDIR)
-	${CXX} ${CXXFLAGS} -c $< -o $@
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(OBJDIR)/%.o: %.c | $(OBJDIR)
-	${CXX} ${CFLAGS} -c $< -o $@
+	$(CXX) $(CFLAGS) -c $< -o $@
 
 $(OBJDIR):
 	mkdir -p $@
@@ -132,9 +260,8 @@ $(OBJDIR):
 $(OBJDIR)/zlib:
 	mkdir -p $@
 
-depend: Rules.depend
+-include $(DEP_FILE)
 
-Rules.depend: Makefile $(SRC)
-	$(CXX) -MM ${INCLUDES} $(SRC) | sed 's|^\([^ ]\)|$(OBJDIR)/\1|' > $@
+endif # VARIANT=shim
 
--include Rules.depend
+endif # VARIANT set

--- a/dll.cpp
+++ b/dll.cpp
@@ -896,7 +896,11 @@ C_DLLEXPORT int Meta_Query (char *ifvers, plugin_info_t **pPlugInfo, mutil_funcs
    gpMetaUtilFuncs = pMetaUtilFuncs;
    *pPlugInfo = &Plugin_info;
 
-   safevoid_snprintf(plugver, sizeof(plugver), "%d.%02d%s", VER_MAJOR, VER_MINOR, VER_NOTE);
+#ifndef VARIANT_VERSION_SUFFIX
+#define VARIANT_VERSION_SUFFIX ""
+#endif
+   safevoid_snprintf(plugver, sizeof(plugver), "%d.%02d%s" VARIANT_VERSION_SUFFIX,
+                     VER_MAJOR, VER_MINOR, VER_NOTE);
    Plugin_info.version = plugver;
 
    // check for interface version compatibility

--- a/shim.c
+++ b/shim.c
@@ -1,0 +1,407 @@
+/*
+ * jk_botti Metamod plugin shim.
+ *
+ * Detects CPU features at runtime and forwards the Metamod plugin entry
+ * points to the matching optimized variant (SSE3 or AVX2+FMA) loaded as
+ * a sibling DLL/shared object.
+ *
+ * MUST be built with plain -march=i686 (no SSE/AVX enabled), since it
+ * runs before we have proven the CPU supports those instruction sets.
+ */
+
+#ifndef _WIN32
+#  define _GNU_SOURCE  /* Dl_info, dladdr */
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#ifndef SHIM_TEST
+#  include <cpuid.h>
+#endif
+
+#ifdef _WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+#  ifdef SHIM_TEST
+#     define DLLEXPORT
+#     define WINAPI_
+#  else
+#     define DLLEXPORT __declspec(dllexport)
+#     define WINAPI_   __stdcall
+#  endif
+#else
+#  include <dlfcn.h>
+#  define DLLEXPORT __attribute__((visibility("default")))
+#  define WINAPI_
+#endif
+
+/* ---- variant filenames (siblings in the shim's own directory) ---------- */
+
+#ifdef _WIN32
+#  define VARIANT_X87     "jk_botti_mm_x87.dll"
+#  define VARIANT_SSE3    "jk_botti_mm_sse3.dll"
+#  define VARIANT_AVX2FMA "jk_botti_mm_avx2fma.dll"
+#else
+#  define VARIANT_X87     "jk_botti_mm_x87_i386.so"
+#  define VARIANT_SSE3    "jk_botti_mm_sse3_i386.so"
+#  define VARIANT_AVX2FMA "jk_botti_mm_avx2fma_i386.so"
+#endif
+
+/* ---- CPU feature detection --------------------------------------------- */
+
+#ifndef SHIM_TEST
+
+static inline uint64_t xgetbv_xcr0(void)
+{
+   uint32_t lo, hi;
+   /* xgetbv with ECX=0 -> (EDX:EAX) = XCR0. */
+   __asm__ volatile ("xgetbv" : "=a"(lo), "=d"(hi) : "c"(0));
+   return ((uint64_t)hi << 32) | lo;
+}
+
+static int has_avx2_fma(void)
+{
+   uint32_t a, b, c, d;
+
+   if (!__get_cpuid(1, &a, &b, &c, &d))
+      return 0;
+   if (!(c & (1u << 27)))               /* OSXSAVE: xgetbv is safe to run */
+      return 0;
+   if ((xgetbv_xcr0() & 0x6u) != 0x6u)  /* OS saves XMM (bit 1) + YMM (bit 2) */
+      return 0;
+   if (!(c & (1u << 28)))               /* AVX */
+      return 0;
+   if (!(c & (1u << 12)))               /* FMA */
+      return 0;
+
+   if (!__get_cpuid_count(7, 0, &a, &b, &c, &d))
+      return 0;
+   if (!(b & (1u << 5)))                /* AVX2 */
+      return 0;
+   return 1;
+}
+
+static int has_sse3(void)
+{
+   uint32_t a, b, c, d;
+   if (!__get_cpuid(1, &a, &b, &c, &d))
+      return 0;
+   return (c & 1u) != 0;                /* SSE3 (implies SSE/SSE2) */
+}
+
+#else /* SHIM_TEST: provided by test harness */
+
+int has_avx2_fma(void);
+int has_sse3(void);
+
+#endif
+
+/* ---- dlopen / LoadLibrary abstraction ---------------------------------- */
+
+#ifdef _WIN32
+typedef HMODULE dl_handle_t;
+#else
+typedef void   *dl_handle_t;
+#endif
+
+static dl_handle_t dl_open(const char *path, char *errbuf, size_t errcap)
+{
+#ifdef _WIN32
+   HMODULE h = LoadLibraryA(path);
+   if (!h)
+      snprintf(errbuf, errcap, "LoadLibrary(%s) failed, GetLastError=%lu",
+               path, (unsigned long)GetLastError());
+   return h;
+#else
+   void *h = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+   if (!h) {
+      const char *e = dlerror();
+      snprintf(errbuf, errcap, "%s", e ? e : "dlopen failed");
+   }
+   return h;
+#endif
+}
+
+static void *dl_sym(dl_handle_t h, const char *name)
+{
+#ifdef _WIN32
+   return (void *)GetProcAddress(h, name);
+#else
+   return dlsym(h, name);
+#endif
+}
+
+/* ---- forward-declaration of variant entry points ----------------------- */
+
+typedef void (WINAPI_ *pfn_GiveFnptrsToDll)(void *, void *);
+typedef int  (*pfn_Meta_Query)(char *, void **, void *);
+typedef int  (*pfn_Meta_Attach)(int, void *, void *, void *);
+typedef int  (*pfn_Meta_Detach)(int, int);
+typedef int  (*pfn_EntityAPI)(void *, int *);
+typedef int  (*pfn_EngineAPI)(void *, int *);
+
+static dl_handle_t          g_variant;
+static pfn_GiveFnptrsToDll  p_GiveFnptrsToDll;
+static pfn_Meta_Query       p_Meta_Query;
+static pfn_Meta_Attach      p_Meta_Attach;
+static pfn_Meta_Detach      p_Meta_Detach;
+static pfn_EntityAPI        p_GetEntityAPI2;
+static pfn_EntityAPI        p_GetEntityAPI2_POST;
+static pfn_EngineAPI        p_GetEngineFunctions;
+static pfn_EngineAPI        p_GetEngineFunctions_POST;
+
+/* ---- self path resolution ---------------------------------------------- */
+
+#ifndef SHIM_TEST
+
+static int self_directory(char *out, size_t cap)
+{
+#ifdef _WIN32
+   HMODULE self = NULL;
+   if (!GetModuleHandleExA(
+           GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+              GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+           (LPCSTR)(void *)&self_directory, &self))
+      return 0;
+   DWORD n = GetModuleFileNameA(self, out, (DWORD)cap);
+   if (n == 0 || n >= cap)
+      return 0;
+#else
+   Dl_info info;
+   if (!dladdr((void *)&self_directory, &info) || !info.dli_fname)
+      return 0;
+   size_t n = strlen(info.dli_fname);
+   if (n + 1 > cap)
+      return 0;
+   memcpy(out, info.dli_fname, n + 1);
+#endif
+
+   /* strip filename, keep trailing separator */
+   size_t i = strlen(out);
+   while (i > 0) {
+      char ch = out[i - 1];
+      if (ch == '/' || ch == '\\') break;
+      --i;
+   }
+   if (i == 0) {
+      if (cap < 3) return 0;
+      out[0] = '.';
+      out[1] = '/';
+      out[2] = 0;
+   } else {
+      out[i] = 0;
+   }
+   return 1;
+}
+
+#else /* SHIM_TEST: provided by test harness */
+
+int self_directory(char *out, size_t cap);
+
+#endif
+
+/* ---- one-shot init ----------------------------------------------------- */
+
+static int g_init_done;
+static int g_init_ok;
+
+static void log_err(const char *msg)
+{
+#ifdef SHIM_TEST
+   (void)msg;  /* tests would drown in detection noise */
+#else
+   fprintf(stderr, "jk_botti shim: %s\n", msg);
+   fflush(stderr);
+#  ifdef _WIN32
+   OutputDebugStringA("jk_botti shim: ");
+   OutputDebugStringA(msg);
+   OutputDebugStringA("\r\n");
+#  endif
+#endif
+}
+
+struct resolve_entry {
+   const char *name;
+   void      **slot;
+};
+
+static int resolve_symbol(dl_handle_t h, const struct resolve_entry *e,
+                          const char *path, char *errbuf, size_t errcap)
+{
+   void *s = dl_sym(h, e->name);
+   if (!s) {
+      snprintf(errbuf, errcap, "symbol %s missing in %s", e->name, path);
+      log_err(errbuf);
+      return 0;
+   }
+   *e->slot = s;
+   return 1;
+}
+
+static int load_variant(const char *dir, const char *leaf)
+{
+   static const struct resolve_entry table[] = {
+      { "GiveFnptrsToDll",         (void **)&p_GiveFnptrsToDll },
+      { "Meta_Query",              (void **)&p_Meta_Query },
+      { "Meta_Attach",             (void **)&p_Meta_Attach },
+      { "Meta_Detach",             (void **)&p_Meta_Detach },
+      { "GetEntityAPI2",           (void **)&p_GetEntityAPI2 },
+      { "GetEntityAPI2_POST",      (void **)&p_GetEntityAPI2_POST },
+      { "GetEngineFunctions",      (void **)&p_GetEngineFunctions },
+      { "GetEngineFunctions_POST", (void **)&p_GetEngineFunctions_POST },
+   };
+
+   char path[1024];
+   char errbuf[2048];
+
+   int n = snprintf(path, sizeof(path), "%s%s", dir, leaf);
+   if (n < 0 || (size_t)n >= sizeof(path)) {
+      log_err("variant path too long");
+      return 0;
+   }
+
+   g_variant = dl_open(path, errbuf, sizeof(errbuf));
+   if (!g_variant) {
+      log_err(errbuf);
+      return 0;
+   }
+
+   for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); ++i) {
+      if (!resolve_symbol(g_variant, &table[i], path, errbuf, sizeof(errbuf)))
+         return 0;
+   }
+
+#ifndef SHIM_TEST
+   fprintf(stderr, "jk_botti shim: loaded variant %s\n", path);
+   fflush(stderr);
+#endif
+   return 1;
+}
+
+static int ensure_loaded(void)
+{
+   if (g_init_done)
+      return g_init_ok;
+   g_init_done = 1;
+
+   char dir[1024];
+   if (!self_directory(dir, sizeof(dir))) {
+      log_err("could not determine own path");
+      return 0;
+   }
+
+   /* Try the best supported variant first, fall back step by step. */
+   const char *candidates[3];
+   int n = 0;
+   if (has_avx2_fma()) candidates[n++] = VARIANT_AVX2FMA;
+   if (has_sse3())     candidates[n++] = VARIANT_SSE3;
+   candidates[n++] = VARIANT_X87;   /* always safe on -march=i686 hardware */
+
+   for (int i = 0; i < n; ++i) {
+      if (i > 0) {
+         char msg[128];
+         snprintf(msg, sizeof(msg), "falling back to %s", candidates[i]);
+         log_err(msg);
+      }
+      if (load_variant(dir, candidates[i])) {
+         g_init_ok = 1;
+         return 1;
+      }
+   }
+   return 0;
+}
+
+/* ---- exported Metamod entry points ------------------------------------- */
+
+DLLEXPORT void WINAPI_ GiveFnptrsToDll(void *pengfuncsFromEngine,
+                                       void *pGlobals)
+{
+   if (!ensure_loaded())
+      return;
+   p_GiveFnptrsToDll(pengfuncsFromEngine, pGlobals);
+}
+
+DLLEXPORT int Meta_Query(char *ifvers, void **pPlugInfo,
+                         void *pMetaUtilFuncs)
+{
+   if (!ensure_loaded())
+      return 0;
+   return p_Meta_Query(ifvers, pPlugInfo, pMetaUtilFuncs);
+}
+
+DLLEXPORT int Meta_Attach(int now, void *pFunctionTable,
+                          void *pMGlobals, void *pGamedllFuncs)
+{
+   if (!ensure_loaded())
+      return 0;
+   return p_Meta_Attach(now, pFunctionTable, pMGlobals, pGamedllFuncs);
+}
+
+DLLEXPORT int Meta_Detach(int now, int reason)
+{
+   if (!g_init_ok)
+      return 1;
+   return p_Meta_Detach(now, reason);
+}
+
+DLLEXPORT int GetEntityAPI2(void *pFunctionTable, int *interfaceVersion)
+{
+   if (!ensure_loaded())
+      return 0;
+   return p_GetEntityAPI2(pFunctionTable, interfaceVersion);
+}
+
+DLLEXPORT int GetEntityAPI2_POST(void *pFunctionTable, int *interfaceVersion)
+{
+   if (!ensure_loaded())
+      return 0;
+   return p_GetEntityAPI2_POST(pFunctionTable, interfaceVersion);
+}
+
+DLLEXPORT int GetEngineFunctions(void *pengfuncsFromEngine,
+                                 int *interfaceVersion)
+{
+   if (!ensure_loaded())
+      return 0;
+   return p_GetEngineFunctions(pengfuncsFromEngine, interfaceVersion);
+}
+
+DLLEXPORT int GetEngineFunctions_POST(void *pengfuncsFromEngine,
+                                      int *interfaceVersion)
+{
+   if (!ensure_loaded())
+      return 0;
+   return p_GetEngineFunctions_POST(pengfuncsFromEngine, interfaceVersion);
+}
+
+#if defined(_WIN32) && !defined(SHIM_TEST)
+BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved)
+{
+   (void)hinst; (void)reason; (void)reserved;
+   return TRUE;
+}
+#endif
+
+#ifdef SHIM_TEST
+/* Test-only accessors for unit-testing the shim. */
+void shim_test_reset(void)
+{
+   g_init_done = 0;
+   g_init_ok = 0;
+   g_variant = NULL;
+   p_GiveFnptrsToDll = NULL;
+   p_Meta_Query = NULL;
+   p_Meta_Attach = NULL;
+   p_Meta_Detach = NULL;
+   p_GetEntityAPI2 = NULL;
+   p_GetEntityAPI2_POST = NULL;
+   p_GetEngineFunctions = NULL;
+   p_GetEngineFunctions_POST = NULL;
+}
+
+int shim_test_ensure_loaded(void)             { return ensure_loaded(); }
+int shim_test_load_variant(const char *dir,
+                           const char *leaf)  { return load_variant(dir, leaf); }
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -153,7 +153,7 @@ test_commands: $(COMMANDS_OBJS)
 
 # dll tests (dll.cpp needs VER_NOTE as a proper C string literal)
 dll.o: ../dll.cpp
-	${CXX} ${TEST_CXXFLAGS} -UVER_NOTE -DVER_NOTE='"test"' -UVER_MAJOR -DVER_MAJOR=0 -UVER_MINOR -DVER_MINOR=0 -c $< -o $@
+	${CXX} ${TEST_CXXFLAGS} -UVER_NOTE -DVER_NOTE='"test"' -UVER_MAJOR -DVER_MAJOR=0 -UVER_MINOR -DVER_MINOR=0 -UVARIANT_VERSION_SUFFIX -c $< -o $@
 
 DLL_OBJS = engine_mock.o test_dll.o \
 	dll.o bot_trace.o bot_weapons.o bot_sound.o util.o safe_snprintf.o random_num.o
@@ -192,13 +192,20 @@ test_bot_query_hook_win32.o: test_bot_query_hook_win32.cpp ../bot_query_hook_win
 test_bot_query_hook_win32: test_bot_query_hook_win32.o
 	${CXX} $(COVERAGE_FLAGS) -o $@ test_bot_query_hook_win32.o
 
+# shim tests (shim.c #included with -D_WIN32 -DSHIM_TEST, mock Win32 headers)
+test_shim.o: test_shim.cpp ../shim.c windows.h
+	${CXX} -Wall -D_WIN32 -DSHIM_TEST -I. -I".." $(COVERAGE_FLAGS) -c $< -o $@
+
+test_shim: test_shim.o
+	${CXX} $(COVERAGE_FLAGS) -o $@ test_shim.o
+
 BOT_TRACE_OBJS = engine_mock.o test_bot_trace.o \
 	bot_trace.o bot_weapons.o util.o safe_snprintf.o random_num.o
 
 test_bot_trace: $(BOT_TRACE_OBJS)
 	${CXX} $(COVERAGE_FLAGS) -o $@ $(BOT_TRACE_OBJS) -lm
 
-ALL_TESTS = test_name_sanitize test_posdata_list test_bot_combat test_bot_weapons test_util test_util_math test_bot_chat test_safe_snprintf test_random_num test_neuralnet test_geneticalg test_waypoint test_bot_navigate test_bot_skill test_bot_sound test_h_export test_bot_config_init test_bot_models test_bot_client test_bot test_commands test_dll test_engine test_bot_trace test_bot_query_hook test_bot_query_hook_linux test_bot_query_hook_win32
+ALL_TESTS = test_name_sanitize test_posdata_list test_bot_combat test_bot_weapons test_util test_util_math test_bot_chat test_safe_snprintf test_random_num test_neuralnet test_geneticalg test_waypoint test_bot_navigate test_bot_skill test_bot_sound test_h_export test_bot_config_init test_bot_models test_bot_client test_bot test_commands test_dll test_engine test_bot_trace test_bot_query_hook test_bot_query_hook_linux test_bot_query_hook_win32 test_shim
 
 all: $(ALL_TESTS)
 
@@ -230,6 +237,7 @@ run: $(ALL_TESTS)
 	./test_bot_query_hook
 	./test_bot_query_hook_linux
 	./test_bot_query_hook_win32
+	./test_shim
 
 VALGRIND = valgrind --leak-check=full --error-exitcode=1
 
@@ -261,6 +269,7 @@ valgrind: $(ALL_TESTS)
 	$(VALGRIND) ./test_bot_query_hook
 	$(VALGRIND) ./test_bot_query_hook_linux
 	$(VALGRIND) ./test_bot_query_hook_win32
+	$(VALGRIND) ./test_shim
 
 coverage:
 	$(MAKE) clean

--- a/tests/test_shim.cpp
+++ b/tests/test_shim.cpp
@@ -1,0 +1,284 @@
+//
+// JK_Botti - tests for shim.c
+//
+// Compiles shim.c as the Win32 variant on Linux, mocking LoadLibraryA /
+// GetProcAddress / OutputDebugStringA and the CPU-feature detection helpers.
+// Build with: -D_WIN32 -DSHIM_TEST -I. (tests dir for mock windows.h)
+//
+
+#ifndef _WIN32
+#define _WIN32
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <map>
+#include <vector>
+
+#include "../shim.c"
+
+#include "test_common.h"
+
+// ============================================================
+// Mock state
+// ============================================================
+
+struct MockLib {
+   bool load_ok         = true;
+   bool have_all_syms   = true;
+};
+
+static std::map<std::string, MockLib> mock_libs;
+static std::vector<std::string>       load_attempts;
+static int mock_has_avx2_fma_val = 0;
+static int mock_has_sse3_val     = 0;
+static std::string mock_self_dir = "/mock/";
+
+// ============================================================
+// Mocks of shim.c externals (has_avx2_fma / has_sse3 / self_directory)
+// ============================================================
+
+int has_avx2_fma(void) { return mock_has_avx2_fma_val; }
+int has_sse3(void)     { return mock_has_sse3_val; }
+
+int self_directory(char *out, size_t cap)
+{
+   size_t n = mock_self_dir.size();
+   if (n + 1 > cap) return 0;
+   memcpy(out, mock_self_dir.c_str(), n + 1);
+   return 1;
+}
+
+// ============================================================
+// Mock Win32 API implementations
+// ============================================================
+
+HMODULE LoadLibraryA(const char *name)
+{
+   load_attempts.push_back(name);
+   auto it = mock_libs.find(name);
+   if (it == mock_libs.end() || !it->second.load_ok)
+      return NULL;
+   return reinterpret_cast<HMODULE>(&it->second);
+}
+
+FARPROC GetProcAddress(HMODULE module, const char *name)
+{
+   (void)name;
+   MockLib *lib = reinterpret_cast<MockLib *>(module);
+   if (!lib || !lib->have_all_syms)
+      return NULL;
+   // Non-null sentinel address — shim stores it into its function-pointer slot
+   // but never calls through during these tests.
+   static int fake;
+   return reinterpret_cast<FARPROC>(&fake);
+}
+
+DWORD GetLastError(void) { return 0; }
+void OutputDebugStringA(const char *msg) { (void)msg; }
+
+// ============================================================
+// Helpers
+// ============================================================
+
+static void reset_all(void)
+{
+   shim_test_reset();
+   mock_libs.clear();
+   load_attempts.clear();
+   mock_has_avx2_fma_val = 0;
+   mock_has_sse3_val     = 0;
+   mock_self_dir         = "/mock/";
+}
+
+static void add_lib(const char *leaf, bool load_ok, bool have_all_syms)
+{
+   MockLib m;
+   m.load_ok       = load_ok;
+   m.have_all_syms = have_all_syms;
+   mock_libs[std::string("/mock/") + leaf] = m;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_picks_avx2fma_when_available(void)
+{
+   TEST("ensure_loaded picks avx2fma when available");
+   reset_all();
+   add_lib("jk_botti_mm_avx2fma.dll", true, true);
+   add_lib("jk_botti_mm_sse3.dll",    true, true);
+   add_lib("jk_botti_mm_x87.dll",     true, true);
+   mock_has_avx2_fma_val = 1;
+   mock_has_sse3_val     = 1;
+
+   ASSERT_INT(shim_test_ensure_loaded(), 1);
+   ASSERT_INT((int)load_attempts.size(), 1);
+   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_avx2fma.dll");
+   PASS();
+   return 0;
+}
+
+static int test_picks_sse3_when_no_avx2(void)
+{
+   TEST("ensure_loaded picks sse3 when avx2 unavailable");
+   reset_all();
+   add_lib("jk_botti_mm_sse3.dll", true, true);
+   add_lib("jk_botti_mm_x87.dll",  true, true);
+   mock_has_avx2_fma_val = 0;
+   mock_has_sse3_val     = 1;
+
+   ASSERT_INT(shim_test_ensure_loaded(), 1);
+   ASSERT_INT((int)load_attempts.size(), 1);
+   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_sse3.dll");
+   PASS();
+   return 0;
+}
+
+static int test_picks_x87_when_no_sse3(void)
+{
+   TEST("ensure_loaded picks x87 when sse3 unavailable");
+   reset_all();
+   add_lib("jk_botti_mm_x87.dll", true, true);
+   mock_has_avx2_fma_val = 0;
+   mock_has_sse3_val     = 0;
+
+   ASSERT_INT(shim_test_ensure_loaded(), 1);
+   ASSERT_INT((int)load_attempts.size(), 1);
+   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_x87.dll");
+   PASS();
+   return 0;
+}
+
+static int test_fallback_avx2_load_fails(void)
+{
+   TEST("ensure_loaded falls back sse3 when avx2 load fails");
+   reset_all();
+   add_lib("jk_botti_mm_avx2fma.dll", false, false);  // load fails
+   add_lib("jk_botti_mm_sse3.dll",    true,  true);
+   add_lib("jk_botti_mm_x87.dll",     true,  true);
+   mock_has_avx2_fma_val = 1;
+   mock_has_sse3_val     = 1;
+
+   ASSERT_INT(shim_test_ensure_loaded(), 1);
+   ASSERT_INT((int)load_attempts.size(), 2);
+   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_avx2fma.dll");
+   ASSERT_STR(load_attempts[1].c_str(), "/mock/jk_botti_mm_sse3.dll");
+   PASS();
+   return 0;
+}
+
+static int test_fallback_missing_symbols(void)
+{
+   TEST("ensure_loaded falls back when symbol missing");
+   reset_all();
+   add_lib("jk_botti_mm_avx2fma.dll", true,  false); // loads but missing syms
+   add_lib("jk_botti_mm_sse3.dll",    true,  true);
+   add_lib("jk_botti_mm_x87.dll",     true,  true);
+   mock_has_avx2_fma_val = 1;
+   mock_has_sse3_val     = 1;
+
+   ASSERT_INT(shim_test_ensure_loaded(), 1);
+   ASSERT_INT((int)load_attempts.size(), 2);
+   ASSERT_STR(load_attempts[1].c_str(), "/mock/jk_botti_mm_sse3.dll");
+   PASS();
+   return 0;
+}
+
+static int test_all_fall_back_to_x87(void)
+{
+   TEST("ensure_loaded falls through avx2->sse3->x87");
+   reset_all();
+   add_lib("jk_botti_mm_avx2fma.dll", false, false);
+   add_lib("jk_botti_mm_sse3.dll",    false, false);
+   add_lib("jk_botti_mm_x87.dll",     true,  true);
+   mock_has_avx2_fma_val = 1;
+   mock_has_sse3_val     = 1;
+
+   ASSERT_INT(shim_test_ensure_loaded(), 1);
+   ASSERT_INT((int)load_attempts.size(), 3);
+   ASSERT_STR(load_attempts[2].c_str(), "/mock/jk_botti_mm_x87.dll");
+   PASS();
+   return 0;
+}
+
+static int test_all_loads_fail(void)
+{
+   TEST("ensure_loaded returns 0 when every variant fails");
+   reset_all();
+   mock_has_avx2_fma_val = 1;
+   mock_has_sse3_val     = 1;
+
+   ASSERT_INT(shim_test_ensure_loaded(), 0);
+   ASSERT_INT((int)load_attempts.size(), 3);
+   PASS();
+   return 0;
+}
+
+static int test_init_is_sticky(void)
+{
+   TEST("ensure_loaded returns cached result on second call");
+   reset_all();
+   add_lib("jk_botti_mm_sse3.dll", true, true);
+   add_lib("jk_botti_mm_x87.dll",  true, true);
+   mock_has_avx2_fma_val = 0;
+   mock_has_sse3_val     = 1;
+
+   ASSERT_INT(shim_test_ensure_loaded(), 1);
+   ASSERT_INT((int)load_attempts.size(), 1);
+
+   // Second call must not retry loads
+   ASSERT_INT(shim_test_ensure_loaded(), 1);
+   ASSERT_INT((int)load_attempts.size(), 1);
+   PASS();
+   return 0;
+}
+
+static int test_load_variant_direct_ok(void)
+{
+   TEST("load_variant succeeds when library + symbols present");
+   reset_all();
+   add_lib("jk_botti_mm_sse3.dll", true, true);
+
+   ASSERT_INT(shim_test_load_variant("/mock/", "jk_botti_mm_sse3.dll"), 1);
+   ASSERT_INT((int)load_attempts.size(), 1);
+   PASS();
+   return 0;
+}
+
+static int test_load_variant_direct_missing_sym(void)
+{
+   TEST("load_variant fails when a symbol is missing");
+   reset_all();
+   add_lib("jk_botti_mm_sse3.dll", true, false);
+
+   ASSERT_INT(shim_test_load_variant("/mock/", "jk_botti_mm_sse3.dll"), 0);
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// main
+// ============================================================
+
+int main(void)
+{
+   int fail = 0;
+
+   printf("test_shim:\n");
+   fail |= test_picks_avx2fma_when_available();
+   fail |= test_picks_sse3_when_no_avx2();
+   fail |= test_picks_x87_when_no_sse3();
+   fail |= test_fallback_avx2_load_fails();
+   fail |= test_fallback_missing_symbols();
+   fail |= test_all_fall_back_to_x87();
+   fail |= test_all_loads_fail();
+   fail |= test_init_is_sticky();
+   fail |= test_load_variant_direct_ok();
+   fail |= test_load_variant_direct_missing_sym();
+
+   printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+   return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/windows.h
+++ b/tests/windows.h
@@ -1,10 +1,11 @@
-// Mock windows.h for testing bot_query_hook_win32.cpp on Linux
+// Mock windows.h for testing Win32 code paths on Linux
 #ifndef MOCK_WINDOWS_H
 #define MOCK_WINDOWS_H
 
 #include <stddef.h>
 
 #define PASCAL
+#define WINAPI
 #define PAGE_READWRITE 0x04
 
 #ifndef _MOCK_DWORD_DEFINED
@@ -26,5 +27,7 @@ HMODULE GetModuleHandle(const char *name);
 FARPROC GetProcAddress(HMODULE module, const char *name);
 BOOL VirtualProtect(void *addr, size_t size, DWORD newprotect, DWORD *oldprotect);
 DWORD GetLastError(void);
+HMODULE LoadLibraryA(const char *name);
+void OutputDebugStringA(const char *msg);
 
 #endif // MOCK_WINDOWS_H


### PR DESCRIPTION
## Summary

- Ship four binaries per platform: a tiny CPUID shim plus three full-plugin builds optimized for different CPU feature levels (x87, sse3, avx2fma).
- Shim (loaded by Metamod as `jk_botti_mm{.dll,_i386.so}`) detects CPU features via CPUID + XGETBV on first entry, then forwards the eight Metamod entry points to the matching sibling binary via dlopen/LoadLibrary.
- Fallback chain: AVX2FMA → SSE3 → x87 (tries next level if preferred variant is missing or fails to load).
- `Plugin_info.version` now carries a `_x87` / `_sse3` / `_avx2fma` suffix so the active variant is visible via `meta list`.

## Design notes

- Shim is compiled with plain `-march=i686` (no SSE/AVX), so it runs safely on pre-SSE3 hardware before feature detection finishes.
- AVX2 detection requires three checks: OSXSAVE, XCR0 bits 1+2 (OS-level YMM save/restore), then the AVX/FMA/AVX2 CPUID bits. This guards against CPUs where AVX silicon exists but the OS hasn't enabled extended state save/restore.
- CPUID is done via GCC's `<cpuid.h>` (portable on mingw-w64 — no libgcc runtime dependency). 
- Metamod ABI surface is narrow (8 C-linkage entry points). After the shim resolves function-pointer tables from the optimized DLL, Metamod calls into the variant directly — zero steady-state overhead.
- Build system: per-variant `obj/<os>-<variant>/` dirs so zlib and object files don't collide across variants.

## Test plan
- [x] Cross-compile all four Linux variants (`jk_botti_mm{,_x87,_sse3,_avx2fma}_i386.so`)
- [x] Cross-compile all four Windows variants (`jk_botti_mm{,_x87,_sse3,_avx2fma}.dll`)
- [x] Verify shim and variants export matching Metamod symbol sets (including `GiveFnptrsToDll@8` stdcall alias on Windows)
- [x] Verify `VARIANT_VERSION_SUFFIX` is baked into each variant's version format string
- [x] Full test suite passes (`make test`)
- [x] Test in real HLDS environment that shim correctly dispatches to AVX2 variant on AVX2 host, SSE3 on pre-AVX2 host
- [x] Verify `meta list` shows variant suffix in plugin version