### PR TITLE
shim: close module handle when variant symbol resolution fails

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -133,6 +133,15 @@ static void *dl_sym(dl_handle_t h, const char *name)
 #endif
 }
 
+static void dl_close(dl_handle_t h)
+{
+#ifdef _WIN32
+   FreeLibrary(h);
+#else
+   dlclose(h);
+#endif
+}
+
 /* ---- forward-declaration of variant entry points ----------------------- */
 
 typedef void (WINAPI_ *pfn_GiveFnptrsToDll)(void *, void *);
@@ -269,8 +278,13 @@ static int load_variant(const char *dir, const char *leaf)
    }
 
    for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); ++i) {
-      if (!resolve_symbol(g_variant, &table[i], path, errbuf, sizeof(errbuf)))
+      if (!resolve_symbol(g_variant, &table[i], path, errbuf, sizeof(errbuf))) {
+         dl_close(g_variant);
+         g_variant = NULL;
+         for (size_t j = 0; j < sizeof(table) / sizeof(table[0]); ++j)
+            *table[j].slot = NULL;
          return 0;
+      }
    }
 
 #ifndef SHIM_TEST

--- a/tests/test_shim.cpp
+++ b/tests/test_shim.cpp
@@ -31,6 +31,7 @@ struct MockLib {
 
 static std::map<std::string, MockLib> mock_libs;
 static std::vector<std::string>       load_attempts;
+static std::vector<MockLib *>         free_attempts;
 static int mock_has_avx2_fma_val = 0;
 static int mock_has_sse3_val     = 0;
 static std::string mock_self_dir = "/mock/";
@@ -75,6 +76,12 @@ FARPROC GetProcAddress(HMODULE module, const char *name)
    return reinterpret_cast<FARPROC>(&fake);
 }
 
+BOOL FreeLibrary(HMODULE module)
+{
+   free_attempts.push_back(reinterpret_cast<MockLib *>(module));
+   return 1;
+}
+
 DWORD GetLastError(void) { return 0; }
 void OutputDebugStringA(const char *msg) { (void)msg; }
 
@@ -87,6 +94,7 @@ static void reset_all(void)
    shim_test_reset();
    mock_libs.clear();
    load_attempts.clear();
+   free_attempts.clear();
    mock_has_avx2_fma_val = 0;
    mock_has_sse3_val     = 0;
    mock_self_dir         = "/mock/";
@@ -259,6 +267,44 @@ static int test_load_variant_direct_missing_sym(void)
    return 0;
 }
 
+static int test_load_variant_closes_handle_on_sym_failure(void)
+{
+   TEST("load_variant closes module handle when symbol resolution fails");
+   reset_all();
+   add_lib("jk_botti_mm_sse3.dll", true, false);
+
+   ASSERT_INT(shim_test_load_variant("/mock/", "jk_botti_mm_sse3.dll"), 0);
+   ASSERT_INT((int)free_attempts.size(), 1);
+   MockLib *loaded = &mock_libs["/mock/jk_botti_mm_sse3.dll"];
+   if (free_attempts[0] != loaded) {
+      printf("  FreeLibrary called on wrong handle\n");
+      return 1;
+   }
+   PASS();
+   return 0;
+}
+
+static int test_fallback_frees_handle_on_sym_failure(void)
+{
+   TEST("fallback path frees handle from variant with missing symbols");
+   reset_all();
+   add_lib("jk_botti_mm_avx2fma.dll", true,  false);  // loads, no syms
+   add_lib("jk_botti_mm_sse3.dll",    true,  true);
+   add_lib("jk_botti_mm_x87.dll",     true,  true);
+   mock_has_avx2_fma_val = 1;
+   mock_has_sse3_val     = 1;
+
+   ASSERT_INT(shim_test_ensure_loaded(), 1);
+   ASSERT_INT((int)free_attempts.size(), 1);
+   MockLib *avx = &mock_libs["/mock/jk_botti_mm_avx2fma.dll"];
+   if (free_attempts[0] != avx) {
+      printf("  expected avx2fma handle to be freed\n");
+      return 1;
+   }
+   PASS();
+   return 0;
+}
+
 // ============================================================
 // main
 // ============================================================
@@ -278,6 +324,8 @@ int main(void)
    fail |= test_init_is_sticky();
    fail |= test_load_variant_direct_ok();
    fail |= test_load_variant_direct_missing_sym();
+   fail |= test_load_variant_closes_handle_on_sym_failure();
+   fail |= test_fallback_frees_handle_on_sym_failure();
 
    printf("\n%d/%d tests passed\n", tests_passed, tests_run);
    return fail ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/tests/windows.h
+++ b/tests/windows.h
@@ -28,6 +28,7 @@ FARPROC GetProcAddress(HMODULE module, const char *name);
 BOOL VirtualProtect(void *addr, size_t size, DWORD newprotect, DWORD *oldprotect);
 DWORD GetLastError(void);
 HMODULE LoadLibraryA(const char *name);
+BOOL FreeLibrary(HMODULE module);
 void OutputDebugStringA(const char *msg);
 
 #endif // MOCK_WINDOWS_H


### PR DESCRIPTION
## Summary
- Fixes a module-handle leak in `shim.c` `load_variant()` flagged by Copilot on #107: if a Metamod entry-point symbol was missing, the function returned 0 without closing the handle, and the global `g_variant` was later overwritten by the next fallback candidate — leaking the handle and leaving stale function-pointer slots pointing into the failed variant.
- Adds a `dl_close()` wrapper (`FreeLibrary` / `dlclose`) and, on resolution failure, closes the handle, clears `g_variant`, and resets every function-pointer slot before returning.
- Extends the shim unit tests: the Win32 mock now tracks `FreeLibrary` calls, with new assertions for both the direct `load_variant()` path and the `ensure_loaded()` fallback path.

## Test plan
- [x] `nice make -j16 CXX=i686-linux-gnu-g++ CC=i686-linux-gnu-gcc AR="i686-linux-gnu-ar rc" RANLIB=i686-linux-gnu-ranlib test` — 12/12 `test_shim` tests pass, including the two new cases.
- [x] `nice make -j16 ... shim` builds the 32-bit shim `.so` cleanly.