### PR TITLE
{bot,dll}: rework timing code

### DIFF
--- a/bot.cpp
+++ b/bot.cpp
@@ -99,9 +99,6 @@ void BotKick(bot_t &pBot)
 //
 static void BotSpawnInit_TimersAndPhysics( bot_t &pBot )
 {
-   pBot.bot_think_time = -1.0;
-   pBot.f_last_think_time = gpGlobals->time - 0.1;
-
    pBot.f_recoil = 0;
 
    pBot.v_prev_origin = Vector(9999.0, 9999.0, 9999.0);
@@ -138,6 +135,8 @@ static void BotSpawnInit_TimersAndPhysics( bot_t &pBot )
    pBot.b_has_enough_ammo_for_good_weapon = 0;
    pBot.b_only_has_weak_weapons = 0;
    pBot.b_low_health = 0;
+
+   pBot.f_frame_accumulator = bot_think_spf;
 }
 
 
@@ -2781,60 +2780,36 @@ static void BotRunPlayerMove(bot_t &pBot, const float *viewangles, float forward
 
 static void BotThinkUpdateFrameTiming(bot_t &pBot)
 {
-   // New code, BotThink is not run on every StartFrame anymore.
-   pBot.f_frame_time = gpGlobals->time - pBot.f_last_think_time;
-   pBot.f_last_think_time = gpGlobals->time;
+   float frame_time = bot_think_spf;
+   float msec = frame_time * 1000.0f;
 
-   pBot.msecval = (int)(pBot.f_frame_time * 1000.0);
-
-   // count up difference that integer conversion caused
-   pBot.msecdel += pBot.f_frame_time * 1000.0 - pBot.msecval;
-
-   // remove effect of integer conversion and lost msecs on previous frames
-   if(pBot.msecdel > 1.625f)
+   if (msec < 1.0f)
    {
-      float diff = 1.625f;
-
-      if(pBot.msecdel > 60.0f)
-         diff = 60.0f;
-      else if(pBot.msecdel > 30.0f)
-         diff = 30.0f;
-      else if(pBot.msecdel > 15.0f)
-         diff = 15.0f;
-      else if(pBot.msecdel > 7.5f)
-         diff = 7.5f;
-      else if(pBot.msecdel > 3.25f)
-         diff = 3.25f;
-
-      pBot.msecval += diff - 0.5f;
-      pBot.msecdel -= diff - 0.5f;
+      // msec too small for the engine, simulate 1ms, putting us ahead.
+      pBot.f_frame_time = 0.001f; // 0.001s/frame = 1000 fps
+      pBot.msecval = 1.0f;
+      pBot.f_frame_accumulator += bot_think_spf - pBot.f_frame_time;
+      return;
    }
 
-   if (pBot.msecval < 1)    // don't allow msec to be less than 1...
+   if (msec > 100.0f)
    {
-      // adjust msecdel so we can correct lost msecs on following frames
-      pBot.msecdel += pBot.msecval - 1;
-      pBot.msecval = 1;
-   }
-   else if (pBot.msecval > 100)  // ...or greater than 100
-   {
-      // adjust msecdel so we can correct lost msecs on following frames
-      pBot.msecdel += pBot.msecval - 100;
-      pBot.msecval = 100;
+      // msec too large for the engine, simulate 100ms, putting us less-behind.
+      pBot.f_frame_time = 0.1f; // 0.1s/frame == 10fps
+      pBot.msecval = 100.0f;
+      pBot.f_frame_accumulator += bot_think_spf - pBot.f_frame_time;
+      return;
    }
 
-   pBot.total_msecval += pBot.msecval / 1000.0;
-   pBot.total_frame_time += pBot.f_frame_time;
+   // msec is just right for the engine, simulate trunc(msec), putting us where we should be.
+   float ms_whole = truncf(msec);
+   float ms_frac = msec - ms_whole;
 
-#if _DEBUG
-   if(&pBot==&bots[0] && pBot.total_counter++ > 10)
-   {
-      UTIL_ConsolePrintf("total msecval count   : %9.4f", pBot.total_msecval);
-      UTIL_ConsolePrintf("total frame time count: %9.4f", pBot.total_frame_time);
-      UTIL_ConsolePrintf("total difference      : %9.4f", pBot.total_frame_time - pBot.total_msecval);
-      pBot.total_counter=1;
-   }
-#endif
+   pBot.f_frame_time = frame_time;
+   pBot.msecval = ms_whole;
+
+   // Add any sub-millisecond time back to the accumulator so we don't lose it.
+   pBot.f_frame_accumulator += ms_frac / 1000.0f;
 }
 
 

--- a/bot.h
+++ b/bot.h
@@ -171,10 +171,8 @@ typedef struct
    float idle_angle_time;
    float blinded_time;
 
-   float bot_think_time;
-   float f_last_think_time;
+   float f_frame_accumulator;
 
-   float msecdel;
    float msecval;
 
    float f_max_speed;
@@ -306,11 +304,6 @@ typedef struct
 
    bot_current_weapon_t current_weapon;  // one current weapon for each bot
    int m_rgAmmo[MAX_AMMO_SLOTS];  // total ammo amounts (1 array for each bot)
-
-// for counting msec effency
-   float total_frame_time;
-   float total_msecval;
-   int total_counter;
 } bot_t;
 
 #define MAX_TEAMS 32

--- a/dll.cpp
+++ b/dll.cpp
@@ -587,18 +587,70 @@ static void PM_Move(struct playermove_s *ppmove, qboolean server)
 
 static void StartFrameUpdateBots(void)
 {
+   static float last_frame_time = 0.0;
+   static qboolean first_frame = TRUE;
+
+   float frame_delta = 0.0;
+
+   if (first_frame)
+   {
+      first_frame = FALSE;
+      last_frame_time = gpGlobals->time;
+   }
+
+   frame_delta = gpGlobals->time - last_frame_time;
+
+   // Prevent it going negative (in case gpGlobals->time is non-monotonic).
+   frame_delta = fmaxf(frame_delta, 0.0f);
+
+   // Never let it run at < 4fps. Prevents stalls if frame_delta gets large.
+   // This could also be done by limiting the inner BotThink() loop and letting
+   // the time accumulate, but this is realistically rare, so choose the simpler
+   // option.
+   frame_delta = fminf(frame_delta, 0.25f);
+
+   last_frame_time = gpGlobals->time;
+
    int count = 0;
+
+
+#define BOT_DEBUG_TICK 0
+
+#if BOT_DEBUG_TICK
+   if(gpGlobals->maxClients > 0) {
+      UTIL_ConsolePrintf("----StartFrameUpdateBots----\n");
+      UTIL_ConsolePrintf("  frame_delta     = %f\n", frame_delta);
+      UTIL_ConsolePrintf("  gpGlobals->time = %f\n", gpGlobals->time);
+   }
+#endif
 
    for (int bot_index = 0; bot_index < gpGlobals->maxClients; bot_index++)
    {
-      if (bots[bot_index].is_used)   // is this slot used
-      {
-         if (gpGlobals->time >= bots[bot_index].bot_think_time)
-         {
-            BotThink(bots[bot_index]);
+      bot_t& bot = bots[bot_index];
 
+      if (bot.is_used)
+      {
+         qboolean did_tick = FALSE;
+
+         bot.f_frame_accumulator += frame_delta;
+
+         while (bot.f_frame_accumulator >= bot_think_spf)
+         {
+#if BOT_DEBUG_TICK
+            //if (bot_index == 0)
+            {
+               UTIL_ConsolePrintf("  tick bot %d, accumulator = %f, msecval = %f\n", bot_index, bot.f_frame_accumulator, bot.msecval);
+            }
+#endif
+            BotThink(bot);
+            bot.f_frame_accumulator -= bot_think_spf;
+            did_tick = TRUE;
+         }
+
+         if (did_tick)
+         {
             // randomness prevents all bots to run on same frame -> less laggy server
-            bots[bot_index].bot_think_time = gpGlobals->time + bot_think_spf * RANDOM_FLOAT2(0.95, 1.05);
+            bot.f_frame_accumulator -= bot_think_spf * RANDOM_FLOAT2(-0.05f, 0.05f);
          }
 
          count++;

--- a/tests/test_bot.cpp
+++ b/tests/test_bot.cpp
@@ -440,7 +440,7 @@ static void setup_bot_for_test(bot_t &pBot, edict_t *pEdict)
    pBot.v_bot_see_enemy_origin = Vector(-99999, -99999, -99999);
    pBot.f_frame_time = 0.01f;
    pBot.f_max_speed = 320.0f;
-   pBot.f_last_think_time = gpGlobals->time - 0.033f;
+   pBot.f_frame_accumulator = 0.033;
    pBot.f_move_direction = 1.0f;
    pBot.userid = 1;
    strcpy(pBot.name, "TestBot");
@@ -636,7 +636,7 @@ static int test_BotSpawnInit_resets_fields(void)
 
    BotSpawnInit(bot);
 
-   ASSERT_TRUE(bot.bot_think_time < 0);
+   ASSERT_FLOAT(bot.f_frame_accumulator, 1.0f / 30.0f);
    ASSERT_PTR_NULL(bot.pBotEnemy);
    ASSERT_FLOAT(bot.f_pause_time, 0.0f);
    ASSERT_TRUE(bot.b_see_tripmine == FALSE);
@@ -2028,68 +2028,83 @@ static int test_BotThink_userid_fill(void)
    return 0;
 }
 
-static int test_BotThink_msec_calculation(void)
+static int test_BotThink_restores_sub_ms_to_accumulator(void)
 {
-   TEST("BotThink: msecval calculated from frame time");
+   TEST("BotThink: restores sub-ms to accumulator");
    setup_engine_funcs();
 
    edict_t *e = mock_alloc_edict();
    bot_t bot;
    setup_bot_for_test(bot, e);
-   bot.f_last_think_time = gpGlobals->time - 0.050f; // 50ms frame
-   bot.msecdel = 0;
+   bot.f_frame_accumulator = 0.050f; // 50ms accumulated time
    e->v.health = 0;
    e->v.deadflag = DEAD_DEAD;
    bot.need_to_initialize = FALSE;
 
    BotThink(bot);
 
-   // msecval should be approximately 50
-   ASSERT_TRUE(bot.msecval >= 49 && bot.msecval <= 51);
+   // Valid for the engine.
+   // Thinks 33ms, restores sub-ms to the accumulator.
+   ASSERT_FLOAT(bot.msecval, 33.0f);
+   ASSERT_FLOAT(bot.f_frame_accumulator, 0.0503333);
 
    PASS();
    return 0;
 }
 
-static int test_BotThink_msec_clamped_min(void)
+static int test_BotThink_handle_extremely_fast_ticks(void)
 {
-   TEST("BotThink: msecval clamped to minimum 1");
+   TEST("BotThink: handles extremely fast ticks");
    setup_engine_funcs();
 
    edict_t *e = mock_alloc_edict();
    bot_t bot;
    setup_bot_for_test(bot, e);
-   bot.f_last_think_time = gpGlobals->time - 0.0001f; // very small frame
-   bot.msecdel = 0;
+   bot.f_frame_accumulator = 0.0f;
    e->v.health = 0;
    e->v.deadflag = DEAD_DEAD;
    bot.need_to_initialize = FALSE;
 
+   float old_spf = bot_think_spf;
+   bot_think_spf = 1 / 2000.0f; // 0.0005s, 2000fps
+
    BotThink(bot);
 
-   ASSERT_TRUE(bot.msecval >= 1);
+   bot_think_spf = old_spf;
+
+   // Too fast for the engine.
+   // Thinks 1ms, taking more time than we have. Accumulator should go negative.
+   ASSERT_FLOAT(bot.msecval, 1.0f);
+   ASSERT_FLOAT(bot.f_frame_accumulator, -0.0005f);
 
    PASS();
    return 0;
 }
 
-static int test_BotThink_msec_clamped_max(void)
+static int test_BotThink_handle_extremely_slow_ticks(void)
 {
-   TEST("BotThink: msecval clamped to maximum 100");
+   TEST("BotThink: handles extremely slow ticks");
    setup_engine_funcs();
 
    edict_t *e = mock_alloc_edict();
    bot_t bot;
    setup_bot_for_test(bot, e);
-   bot.f_last_think_time = gpGlobals->time - 0.500f; // 500ms frame
-   bot.msecdel = 0;
+   bot.f_frame_accumulator = 0.0f;
    e->v.health = 0;
    e->v.deadflag = DEAD_DEAD;
    bot.need_to_initialize = FALSE;
 
+   float old_spf = bot_think_spf;
+   bot_think_spf = 1000.0f; /* 0.001 fps */
+
    BotThink(bot);
 
-   ASSERT_TRUE(bot.msecval <= 100);
+   bot_think_spf = old_spf;
+
+   // Too slow for the engine.
+   // Thinks 100ms, can't consume enough. Accumulator should be added to.
+   ASSERT_FLOAT(bot.msecval, 100.0f);
+   ASSERT_FLOAT(bot.f_frame_accumulator, 999.9);
 
    PASS();
    return 0;
@@ -3586,40 +3601,6 @@ static int test_BotDoRandom_duck_start(void)
 // BotThink branches
 // ============================================================
 
-static int test_BotThink_msecdel_correction(void)
-{
-   TEST("BotThink: msecdel > 1.625 -> correction applied");
-   setup_engine_funcs();
-
-   edict_t *e = mock_alloc_edict();
-   bot_t bot;
-   setup_bot_for_test(bot, e);
-   bot.need_to_initialize = FALSE;
-   bot.msecdel = 5.0f; // > 3.25
-   bot.f_speed_check_time = gpGlobals->time + 10.0f;
-   bot.v_prev_origin = e->v.origin;
-
-   // Pause to simplify
-   bot.f_pause_time = gpGlobals->time + 5.0f;
-
-   for (int i = 0; i < 5; i++)
-   {
-      skill_settings[i].pause_frequency = 0;
-      skill_settings[i].normal_strafe = 0;
-      skill_settings[i].random_jump_frequency = 0;
-      skill_settings[i].random_duck_frequency = 0;
-      skill_settings[i].random_longjump_frequency = 0;
-   }
-
-   BotThink(bot);
-
-   // msecdel should have been reduced by the correction
-   ASSERT_TRUE(bot.msecdel < 5.0f);
-
-   PASS();
-   return 0;
-}
-
 static int test_BotThink_recently_attacked_resets_pause(void)
 {
    TEST("BotThink: recently attacked -> resets pause");
@@ -3874,26 +3855,6 @@ static int test_BotThink_duck_time_active(void)
    BotThink(bot);
 
    ASSERT_TRUE(FBitSet(e->v.button, IN_DUCK));
-
-   PASS();
-   return 0;
-}
-
-static int test_BotThink_msecdel_large_values(void)
-{
-   TEST("BotThink: msecdel=65 -> correction chain applied");
-   setup_engine_funcs();
-
-   edict_t *e = mock_alloc_edict();
-   bot_t bot;
-   setup_alive_bot(bot, e);
-   bot.msecdel = 65.0f; // > 60
-   bot.f_pause_time = gpGlobals->time + 5.0f;
-
-   BotThink(bot);
-
-   // msecdel should have been reduced significantly
-   ASSERT_TRUE(bot.msecdel < 65.0f);
 
    PASS();
    return 0;
@@ -5475,9 +5436,9 @@ int main(void)
    fail |= test_BotThink_alive_basic();
    fail |= test_BotThink_name_fill();
    fail |= test_BotThink_userid_fill();
-   fail |= test_BotThink_msec_calculation();
-   fail |= test_BotThink_msec_clamped_min();
-   fail |= test_BotThink_msec_clamped_max();
+   fail |= test_BotThink_restores_sub_ms_to_accumulator();
+   fail |= test_BotThink_handle_extremely_fast_ticks();
+   fail |= test_BotThink_handle_extremely_slow_ticks();
    fail |= test_BotThink_detects_ground();
    fail |= test_BotThink_detects_ladder();
    fail |= test_BotThink_detects_water();
@@ -5488,7 +5449,6 @@ int main(void)
    fail |= test_BotThink_grenade_reverse();
    fail |= test_BotThink_door_waypoint_slows();
    fail |= test_BotThink_crouch_waypoint();
-   fail |= test_BotThink_msecdel_correction();
    fail |= test_BotThink_recently_attacked_resets_pause();
    fail |= test_BotThink_lift_end_waypoint();
    fail |= test_BotThink_pause_look_idealpitch();
@@ -5526,7 +5486,6 @@ int main(void)
    fail |= test_BotCreate_max_bots_reached();
    fail |= test_BotInFieldOfView_negative_angle();
    fail |= test_BotThink_duck_time_active();
-   fail |= test_BotThink_msecdel_large_values();
    fail |= test_BotCheckLogoSpraying_left_wall();
    fail |= test_BotCheckLogoSpraying_behind();
 

--- a/tests/test_dll.cpp
+++ b/tests/test_dll.cpp
@@ -1746,8 +1746,11 @@ static int test_startframe_bot_stop_no_thinking(void)
 
    bots[0].is_used = TRUE;
    bots[0].pEdict = mock_alloc_edict();
-   bots[0].bot_think_time = 0.0;
 
+   bots[0].f_frame_accumulator = 0.0f;
+   api_table.pfnStartFrame();
+
+   bots[0].f_frame_accumulator = 10000.0f; // many, many frames
    api_table.pfnStartFrame();
 
    ASSERT_INT(bot_think_called, 0);
@@ -1774,7 +1777,7 @@ static int test_startframe_normal_with_bot(void)
    edict_t *pBot = mock_alloc_edict();
    bots[0].is_used = TRUE;
    bots[0].pEdict = pBot;
-   bots[0].bot_think_time = 0.0;
+   bots[0].f_frame_accumulator = 1.0f / 30.0f;
 
    gpGlobals->time = 10.0;
 
@@ -1803,10 +1806,12 @@ static int test_startframe_bot_think_time_not_reached(void)
    edict_t *pBot = mock_alloc_edict();
    bots[0].is_used = TRUE;
    bots[0].pEdict = pBot;
-   bots[0].bot_think_time = 999.0;
+   bots[0].f_frame_accumulator = 0;
 
-   gpGlobals->time = 10.0;
+   gpGlobals->time = 0;
+   api_table.pfnStartFrame();
 
+   gpGlobals->time = 0.0166;
    api_table.pfnStartFrame();
 
    ASSERT_INT(bot_think_called, 0);
@@ -1902,7 +1907,7 @@ static int test_startframe_num_bots_tracks_count(void)
    {
       bots[i].is_used = TRUE;
       bots[i].pEdict = mock_alloc_edict();
-      bots[i].bot_think_time = 0.0;
+      bots[i].f_frame_accumulator = 1.0f / 30.0f;
    }
 
    gpGlobals->time = 10.0;
@@ -2581,7 +2586,7 @@ static int test_startframe_bot_remove(void)
 
       bots[i].is_used = TRUE;
       bots[i].pEdict = e;
-      bots[i].bot_think_time = 999.0; // not due yet
+      bots[i].f_frame_accumulator = 0.0f; // not due yet
    }
 
    bot_kick_called = 0;
@@ -2619,7 +2624,7 @@ static int test_startframe_bot_no_add_no_remove(void)
 
       bots[i].is_used = TRUE;
       bots[i].pEdict = e;
-      bots[i].bot_think_time = 999.0;
+      bots[i].f_frame_accumulator = 0.0f;
    }
 
    // client_count=2, bot_count=2


### PR DESCRIPTION
Lock bots to a fixed tick rate, use a per-frame accumulator that can handle a variable timer.

This solves a bunch of timing-related issues I was seeing with long-running sessions (many hours) in a Xash3D-FWGS dedicated server (`v49/0.21 (linux-amd64 build 4037)`).

The bots would behave normally initially, and then as the round progressed, they would eventually start taking longer and longer to "think" or "tick".

In the server console, the debug prints would show `total difference` gradually creeping up with no players in the server (causing the bots to behave "choppy"), and would gradually creep back down when a player joined.

I've been running this on my server for a few hours and haven't seen any of these issues since. I'll leave it run overnight, but I'm pretty sure this fixes it.

EDIT: Confirmed, bots are still working properly after running overnight.
