### PR TITLE
ci: add timeout-minutes to all workflow jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: Update package list for i386
@@ -44,6 +45,7 @@ jobs:
 
   build-linux-bionic:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Build variants in Ubuntu 18.04 i386 container
@@ -67,6 +69,7 @@ jobs:
 
   build-windows:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: Install packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Update package list for i386
@@ -23,6 +24,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: Update package list for i386

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   package-linux:
     runs-on: ubuntu-24.04
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v6
       - name: Download Linux binaries
@@ -39,6 +40,7 @@ jobs:
 
   package-linux-bionic:
     runs-on: ubuntu-24.04
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v6
       - name: Download Linux Bionic binaries
@@ -64,6 +66,7 @@ jobs:
 
   package-windows:
     runs-on: ubuntu-24.04
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v6
       - name: Download Windows binaries
@@ -90,6 +93,7 @@ jobs:
     if: ${{ inputs.create_release }}
     needs: [package-linux, package-linux-bionic, package-windows]
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   validate-tag:
     runs-on: ubuntu-24.04
+    timeout-minutes: 2
     outputs:
       version: ${{ steps.parse.outputs.VERSION }}
       ver_major: ${{ steps.parse.outputs.VER_MAJOR }}


### PR DESCRIPTION
## Summary
- GitHub's default job timeout is 6 hours — too lenient for this project, where the longest job (test + valgrind) normally takes ~3m14s.
- Added `timeout-minutes` to every job across `ci.yml`, `build.yml`, `package.yml`, and `release.yml`, sized at roughly 2–3× observed duration so hung jobs fail fast instead of burning the full default budget.
- Values: `test=10`, `coverage=5`, `build-linux=5`, `build-linux-bionic=10` (extra slack for docker pull variance), `build-windows=5`, `package-*=3`, `create-release=5`, `validate-tag=2`.

## Test plan
- [x] CI run on this PR completes within the new limits.