### PR TITLE
ci: add ASAN+UBSAN sanitizer test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,18 @@ jobs:
       - name: Run valgrind
         run: CXX="g++ -m32" make valgrind
 
+  sanitize:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Update package list for i386
+        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
+      - name: Install packages
+        run: sudo apt-get -y install build-essential g++-multilib
+      - name: Run tests with ASAN and UBSAN
+        run: CXX="g++ -m32" make sanitize
+
   coverage:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -59,7 +71,7 @@ jobs:
     uses: ./.github/workflows/build.yml
 
   package:
-    needs: [test, build]
+    needs: [test, sanitize, build]
     uses: ./.github/workflows/package.yml
     with:
       version: snapshot

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ifeq ($(VARIANT),)
 # Top-level: dispatch variant builds via recursive make.
 # ============================================================================
 
-.PHONY: all variants shim x87 sse3 avx2fma test valgrind coverage clean distclean depend
+.PHONY: all variants shim x87 sse3 avx2fma test valgrind sanitize coverage clean distclean depend
 
 all: variants
 
@@ -90,6 +90,9 @@ test:
 valgrind:
 	$(MAKE) -C tests clean
 	+$(MAKE) VARIANT=sse3 TARGETFLAGS_OVERRIDE="$(VALGRIND_TARGETFLAGS)" _valgrind
+
+sanitize:
+	+$(MAKE) VARIANT=avx2fma _sanitize
 
 coverage:
 	+$(MAKE) VARIANT=avx2fma _coverage
@@ -170,7 +173,7 @@ CFLAGS    = $(BASEFLAGS) $(OPTFLAGS) $(ARCHFLAG) $(INCLUDES)
 CXXFLAGS  = -fno-rtti -fno-exceptions
 CXXFLAGS += $(CFLAGS)
 
-.PHONY: _build _test _valgrind _coverage _depend
+.PHONY: _build _test _valgrind _sanitize _coverage _depend
 
 # ----------------------------------------------------------------------------
 # Shim variant: single-file forwarder, no zlib, no HL SDK headers.
@@ -239,6 +242,9 @@ _test: $(ZLIB_LIB)
 
 _valgrind: $(ZLIB_LIB)
 	$(MAKE) -C tests CXXFLAGS="$(CXXFLAGS)" ZLIB_LIB="../$(ZLIB_LIB)" valgrind
+
+_sanitize: $(ZLIB_LIB)
+	$(MAKE) -C tests CXXFLAGS="$(CXXFLAGS)" ZLIB_LIB="../$(ZLIB_LIB)" sanitize
 
 _coverage: $(ZLIB_LIB)
 	$(MAKE) -C tests CXXFLAGS="$(CXXFLAGS)" ZLIB_LIB="../$(ZLIB_LIB)" coverage

--- a/bot.cpp
+++ b/bot.cpp
@@ -2215,7 +2215,8 @@ static void BotJustWanderAround(bot_t &pBot, float moved_distance)
 static void BotDoStrafeCombat_SelectDirection(bot_t &pBot)
 {
    edict_t *pEdict = pBot.pEdict;
-   bool isMelee = (weapon_select[pBot.current_weapon_index].type & WEAPON_MELEE);
+   bool isMelee = pBot.current_weapon_index >= 0 &&
+                  (weapon_select[pBot.current_weapon_index].type & WEAPON_MELEE);
 
    // don't go too close to enemy
    // strafe instead

--- a/bot_client.cpp
+++ b/bot_client.cpp
@@ -128,8 +128,10 @@ void BotClient_Valve_CurrentWeapon(void *p, int bot_index)
             bots[bot_index].current_weapon.iClip = iClip;
 
             // update the ammo counts for this weapon...
-            bots[bot_index].current_weapon.iAmmo1 = bots[bot_index].m_rgAmmo[weapon_defs[iId].iAmmo1];
-            bots[bot_index].current_weapon.iAmmo2 = bots[bot_index].m_rgAmmo[weapon_defs[iId].iAmmo2];
+            bots[bot_index].current_weapon.iAmmo1 =
+               weapon_defs[iId].iAmmo1 >= 0 ? bots[bot_index].m_rgAmmo[weapon_defs[iId].iAmmo1] : 0;
+            bots[bot_index].current_weapon.iAmmo2 =
+               weapon_defs[iId].iAmmo2 >= 0 ? bots[bot_index].m_rgAmmo[weapon_defs[iId].iAmmo2] : 0;
 
             pSelect = &weapon_select[0];
 
@@ -213,9 +215,9 @@ void BotClient_Valve_AmmoX(void *p, int bot_index)
 
       // update the ammo counts for this weapon...
       bots[bot_index].current_weapon.iAmmo1 =
-         bots[bot_index].m_rgAmmo[weapon_defs[ammo_index].iAmmo1];
+         weapon_defs[ammo_index].iAmmo1 >= 0 ? bots[bot_index].m_rgAmmo[weapon_defs[ammo_index].iAmmo1] : 0;
       bots[bot_index].current_weapon.iAmmo2 =
-         bots[bot_index].m_rgAmmo[weapon_defs[ammo_index].iAmmo2];
+         weapon_defs[ammo_index].iAmmo2 >= 0 ? bots[bot_index].m_rgAmmo[weapon_defs[ammo_index].iAmmo2] : 0;
    }
 }
 
@@ -248,9 +250,9 @@ void BotClient_Valve_AmmoPickup(void *p, int bot_index)
 
       // update the ammo counts for this weapon...
       bots[bot_index].current_weapon.iAmmo1 =
-         bots[bot_index].m_rgAmmo[weapon_defs[ammo_index].iAmmo1];
+         weapon_defs[ammo_index].iAmmo1 >= 0 ? bots[bot_index].m_rgAmmo[weapon_defs[ammo_index].iAmmo1] : 0;
       bots[bot_index].current_weapon.iAmmo2 =
-         bots[bot_index].m_rgAmmo[weapon_defs[ammo_index].iAmmo2];
+         weapon_defs[ammo_index].iAmmo2 >= 0 ? bots[bot_index].m_rgAmmo[weapon_defs[ammo_index].iAmmo2] : 0;
    }
 }
 

--- a/bot_query_hook.cpp
+++ b/bot_query_hook.cpp
@@ -102,7 +102,10 @@ ssize_t PASCAL handle_player_reply(int socket, const void *message, size_t lengt
 
       offset = (size_t)msg - (size_t)message;
 
-      BotReplaceConnectionTime(pname, (float*)&newmsg[offset]);
+      float timeval;
+      memcpy(&timeval, &newmsg[offset], sizeof(float));
+      BotReplaceConnectionTime(pname, &timeval);
+      memcpy(&newmsg[offset], &timeval, sizeof(float));
 
       msg+=4;
       len-=4;

--- a/bot_query_hook_linux.cpp
+++ b/bot_query_hook_linux.cpp
@@ -57,8 +57,9 @@ static pthread_mutex_t mutex_replacement_sendto = PTHREAD_RECURSIVE_MUTEX_INITIA
 //constructs new jmp forwarder
 static void construct_jmp_instruction(void *x, void *place, void *target)
 {
+   unsigned long offset = ((unsigned long)target) - (((unsigned long)place) + 5);
    ((unsigned char *)x)[0] = 0xe9;
-   *(unsigned long *)((char *)x + 1) = ((unsigned long)target) - (((unsigned long)place) + 5);
+   memcpy((char *)x + 1, &offset, sizeof(unsigned long));
 }
 
 //restores old sendto

--- a/bot_query_hook_win32.cpp
+++ b/bot_query_hook_win32.cpp
@@ -28,8 +28,9 @@
 
 //constructs new jmp forwarder
 #define construct_jmp_instruction(x, place, target) { \
+   unsigned long _jmp_offset = ((unsigned long)(target)) - (((unsigned long)(place)) + 5); \
    ((unsigned char *)(x))[0] = 0xe9; \
-   *(unsigned long *)((char *)(x) + 1) = ((unsigned long)(target)) - (((unsigned long)(place)) + 5); \
+   memcpy((char *)(x) + 1, &_jmp_offset, sizeof(unsigned long)); \
 }
 
 //opcode + sizeof pointer

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -271,6 +271,12 @@ valgrind: $(ALL_TESTS)
 	$(VALGRIND) ./test_bot_query_hook_win32
 	$(VALGRIND) ./test_shim
 
+SANITIZE_FLAGS = -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer
+
+sanitize:
+	$(MAKE) clean
+	$(MAKE) COVERAGE_FLAGS="$(SANITIZE_FLAGS)" run
+
 coverage:
 	$(MAKE) clean
 	rm -f *.gcda *.gcno coverage.info

--- a/tests/test_bot_navigate.cpp
+++ b/tests/test_bot_navigate.cpp
@@ -52,7 +52,7 @@ float mock_RANDOM_FLOAT2(float low, float high)
 // Controllable return values for waypoint functions
 static int mock_WaypointFindNearest_result = -1;
 static int mock_WaypointFindReachable_result = -1;
-static int mock_WaypointRouteFromTo_result = -1;
+static int mock_WaypointRouteFromTo_result = WAYPOINT_UNREACHABLE;
 static float mock_WaypointDistanceFromTo_result = 99999.0f;
 
 // WaypointFindPath: returns waypoint indices from a list, one per call
@@ -213,7 +213,7 @@ static void reset_navigate_mocks(void)
 {
    mock_WaypointFindNearest_result = -1;
    mock_WaypointFindReachable_result = -1;
-   mock_WaypointRouteFromTo_result = -1;
+   mock_WaypointRouteFromTo_result = WAYPOINT_UNREACHABLE;
    mock_WaypointDistanceFromTo_result = 99999.0f;
    mock_WaypointFindPath_count = 0;
    mock_WaypointFindPath_call = 0;

--- a/tests/test_waypoint.cpp
+++ b/tests/test_waypoint.cpp
@@ -402,16 +402,16 @@ static int test_WaypointAddDeletePath(void)
 
    TEST("fill to MAX_PATH_INDEX stops at limit");
    reset_waypoint_state();
-   for (int i = 0; i < MAX_PATH_INDEX + 1; i++)
-      setup_waypoint(i, Vector((float)i * 100, 0, 0), 0, 0);
-   for (int i = 1; i <= MAX_PATH_INDEX; i++)
-      setup_path(0, (short int)i);
-   // Should have exactly MAX_PATH_INDEX paths
+   setup_waypoint(0, Vector(0,0,0), 0, 0);
+   setup_waypoint(1, Vector(100,0,0), 0, 0);
+   setup_waypoint(2, Vector(200,0,0), 0, 0);
+   // Manually fill path slots to the limit
+   paths[0].last_idx_used = MAX_PATH_INDEX;
+   for (int i = 0; i < MAX_PATH_INDEX; i++)
+      paths[0].index[i] = 1;
    ASSERT_INT(paths[0].last_idx_used, MAX_PATH_INDEX);
-   // Trying to add one more should be silently ignored
-   int extra = MAX_PATH_INDEX; // already at limit
-   setup_waypoint(extra, Vector(99999,0,0), 0, 0);
-   // Can't add, already at limit
+   // Trying to add a new (non-duplicate) path should be silently ignored
+   setup_path(0, 2);
    ASSERT_INT(paths[0].last_idx_used, MAX_PATH_INDEX);
    PASS();
 


### PR DESCRIPTION
## Summary
- Add `make sanitize` target that rebuilds and runs all tests with `-fsanitize=address,undefined -fno-sanitize-recover=all`
- Add corresponding CI job gating the package step
- Fix 5 production code bugs and 2 test bugs found by the sanitizers:
  - `bot_client.cpp`: OOB `m_rgAmmo[-1]` access for weapons without secondary ammo
  - `bot.cpp`: OOB `weapon_select[-1]` access when no weapon is selected
  - `bot_query_hook.cpp`: unaligned `float*` cast on byte buffer
  - `bot_query_hook_linux.cpp`, `bot_query_hook_win32.cpp`: unaligned write in JMP instruction construction
  - `test_waypoint.cpp`: OOB `waypoints[1024]` in path limit test
  - `test_bot_navigate.cpp`: mock default caused `waypoints[-1]` access

## Test plan
- [x] `make sanitize` passes clean locally (cross-compiled 32-bit)
- [x] `make test` still passes (no regressions)
- [x] Production build compiles without warnings
- [x] CI sanitize job passes on Ubuntu 24.04