### PR TITLE
ci: switch to i686 cross-compiler and add clang CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,19 +20,22 @@ jobs:
   build-linux:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    env:
+      CXX: i686-linux-gnu-g++
+      CC: i686-linux-gnu-gcc
+      AR: "i686-linux-gnu-ar rc"
+      RANLIB: i686-linux-gnu-ranlib
     steps:
       - uses: actions/checkout@v6
-      - name: Update package list for i386
-        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
       - name: Install packages
-        run: sudo apt-get -y install build-essential g++-multilib
+        run: sudo apt-get -y update && sudo apt-get -y install build-essential g++-i686-linux-gnu
       - name: Build variants (shim + x87 + SSE3 + AVX2FMA)
         run: |
           VERFLAGS=""
           if [ -n "${{ inputs.ver_major }}" ]; then
             VERFLAGS="VER_MAJOR=${{ inputs.ver_major }} VER_MINOR=${{ inputs.ver_minor }} VER_NOTE=${{ inputs.ver_note }}"
           fi
-          CC="gcc -m32" CXX="g++ -m32" AR="ar rc" RANLIB="ranlib" make -j4 variants $VERFLAGS
+          make -j4 variants $VERFLAGS
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,45 @@ jobs:
           name: coverage-report
           path: tests/coverage_report
 
+  test-clang:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      CXX: "clang++ --target=i686-linux-gnu"
+      CC: "clang --target=i686-linux-gnu"
+      AR: "i686-linux-gnu-ar rc"
+      RANLIB: i686-linux-gnu-ranlib
+    steps:
+      - uses: actions/checkout@v6
+      - name: Update package list for i386
+        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
+      - name: Install packages
+        run: sudo apt-get -y install build-essential clang g++-i686-linux-gnu libc6:i386 libstdc++6:i386
+      - name: Run tests
+        run: make test
+
+  sanitize-clang:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      CXX: "clang++ --target=i686-linux-gnu"
+      CC: "clang --target=i686-linux-gnu"
+      AR: "i686-linux-gnu-ar rc"
+      RANLIB: i686-linux-gnu-ranlib
+    steps:
+      - uses: actions/checkout@v6
+      - name: Update package list for i386
+        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
+      - name: Install packages
+        run: sudo apt-get -y install build-essential clang g++-i686-linux-gnu libc6:i386 libstdc++6:i386
+      - name: Run tests with ASAN and UBSAN
+        run: make sanitize
+
   build:
     uses: ./.github/workflows/build.yml
 
   package:
-    needs: [test, sanitize, build]
+    needs: [test, sanitize, test-clang, sanitize-clang, build]
     uses: ./.github/workflows/package.yml
     with:
       version: snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,42 +9,57 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    env:
+      CXX: i686-linux-gnu-g++
+      CC: i686-linux-gnu-gcc
+      AR: "i686-linux-gnu-ar rc"
+      RANLIB: i686-linux-gnu-ranlib
     steps:
       - uses: actions/checkout@v6
       - name: Update package list for i386
         run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
       - name: Install packages
-        run: sudo apt-get -y install build-essential g++-multilib
+        run: sudo apt-get -y install build-essential g++-i686-linux-gnu libstdc++6:i386
       - name: Install valgrind
         run: sudo apt-get -y install valgrind libc6-dbg:i386
       - name: Run tests
-        run: CXX="g++ -m32" make test
+        run: make test
       - name: Run valgrind
-        run: CXX="g++ -m32" make valgrind
+        run: make valgrind
 
   sanitize:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    env:
+      CXX: i686-linux-gnu-g++
+      CC: i686-linux-gnu-gcc
+      AR: "i686-linux-gnu-ar rc"
+      RANLIB: i686-linux-gnu-ranlib
     steps:
       - uses: actions/checkout@v6
       - name: Update package list for i386
         run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
       - name: Install packages
-        run: sudo apt-get -y install build-essential g++-multilib
+        run: sudo apt-get -y install build-essential g++-i686-linux-gnu libc6:i386 libstdc++6:i386 libasan8:i386 libubsan1:i386
       - name: Run tests with ASAN and UBSAN
-        run: CXX="g++ -m32" make sanitize
+        run: make sanitize
 
   coverage:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    env:
+      CXX: i686-linux-gnu-g++
+      CC: i686-linux-gnu-gcc
+      AR: "i686-linux-gnu-ar rc"
+      RANLIB: i686-linux-gnu-ranlib
     steps:
       - uses: actions/checkout@v6
       - name: Update package list for i386
         run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
       - name: Install packages
-        run: sudo apt-get -y install build-essential g++-multilib lcov
+        run: sudo apt-get -y install build-essential g++-i686-linux-gnu libc6:i386 libstdc++6:i386 lcov
       - name: Run coverage
-        run: CXX="g++ -m32" make coverage
+        run: make coverage
       - name: Generate job summary
         run: |
           summary=$(lcov --summary tests/coverage.info --branch-coverage \

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,19 @@ endif
 
 TARGET = jk_botti_mm
 
+ifneq ($(findstring clang,$(shell $(firstword $(CXX)) --version 2>/dev/null)),)
+COMPILER_IS_CLANG := 1
+endif
+
 SHIM_TARGETFLAGS    ?= -march=i686 -mtune=generic
 X87_TARGETFLAGS     ?= -march=i686 -mtune=generic
+ifeq ($(COMPILER_IS_CLANG),1)
+SSE3_TARGETFLAGS    ?= -march=i686 -mtune=generic -msse3
+AVX2FMA_TARGETFLAGS ?= -march=i686 -mtune=generic -mavx2 -mfma
+else
 SSE3_TARGETFLAGS    ?= -march=i686 -mtune=generic -msse3 -mfpmath=sse
 AVX2FMA_TARGETFLAGS ?= -march=i686 -mtune=generic -mavx2 -mfma -mfpmath=sse
+endif
 VALGRIND_TARGETFLAGS ?= $(SSE3_TARGETFLAGS)
 
 SHIM_OUT := $(TARGET)$(DLLEND)
@@ -151,9 +160,12 @@ VER_MINOR ?= 0
 VER_NOTE  ?= git$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 VERFLAGS   = -DVER_MAJOR=$(VER_MAJOR) -DVER_MINOR=$(VER_MINOR) -DVER_NOTE=\"$(VER_NOTE)\" $(VERFLAGS_EXTRA)
 
-BASEFLAGS  = -Wall -Wno-write-strings -Wno-class-memaccess $(VERFLAGS)
+BASEFLAGS  = -Wall -Wno-write-strings $(VERFLAGS)
 BASEFLAGS += -fno-strict-aliasing -fno-strict-overflow
-BASEFLAGS += -fvisibility=hidden -mincoming-stack-boundary=2
+BASEFLAGS += -fvisibility=hidden
+ifneq ($(COMPILER_IS_CLANG),1)
+BASEFLAGS += -Wno-class-memaccess -mincoming-stack-boundary=2
+endif
 ARCHFLAG  += $(TARGETFLAGS)
 
 ifeq ($(DBG_FLGS),1)

--- a/tests/test_bot_query_hook_linux.cpp
+++ b/tests/test_bot_query_hook_linux.cpp
@@ -59,7 +59,8 @@ static int test_construct_jmp_basic(void)
    ASSERT_INT(buf[0], 0xE9);
 
    // Check relative offset
-   unsigned long offset = *(unsigned long *)(buf + 1);
+   unsigned long offset;
+   memcpy(&offset, buf + 1, sizeof(offset));
    unsigned long expected = (unsigned long)target - ((unsigned long)place + 5);
    ASSERT_TRUE(offset == expected);
 
@@ -81,7 +82,8 @@ static int test_construct_jmp_backward(void)
 
    ASSERT_INT(buf[0], 0xE9);
 
-   unsigned long offset = *(unsigned long *)(buf + 1);
+   unsigned long offset;
+   memcpy(&offset, buf + 1, sizeof(offset));
    unsigned long expected = (unsigned long)target - ((unsigned long)place + 5);
    ASSERT_TRUE(offset == expected);
 

--- a/tests/test_commands.cpp
+++ b/tests/test_commands.cpp
@@ -134,7 +134,7 @@ static int mock_Cmd_Argc(void)
 static char mock_server_cmd_buf[256];
 static int mock_server_execute_count;
 
-static void mock_pfnServerCommand(const char *str)
+static void mock_pfnServerCommand(char *str)
 {
    if (str)
       safe_strcopy(mock_server_cmd_buf, sizeof(mock_server_cmd_buf), str);
@@ -251,7 +251,7 @@ static void reset_test_state(void)
    g_engfuncs.pfnCmd_Argv = mock_Cmd_Argv;
    g_engfuncs.pfnCmd_Args = mock_Cmd_Args;
    g_engfuncs.pfnCmd_Argc = mock_Cmd_Argc;
-   g_engfuncs.pfnServerCommand = (void (*)(char *))mock_pfnServerCommand;
+   g_engfuncs.pfnServerCommand = mock_pfnServerCommand;
    g_engfuncs.pfnServerExecute = mock_pfnServerExecute;
    g_engfuncs.pfnIsDedicatedServer = mock_pfnIsDedicatedServer;
 

--- a/util.cpp
+++ b/util.cpp
@@ -43,6 +43,11 @@ static int team_model_map_count = 0;
 // [-pi/4, pi/4] and minimax polynomials. Max error vs libm: < 2e-16.
 inline void fsincos_sse(double x, double &s, double &c)
 {
+   if (__builtin_expect(!__builtin_isfinite(x), 0)) {
+      s = c = __builtin_nan("");
+      return;
+   }
+
    double abs_x = __builtin_fabs(x);
 
    // Find octant: j = floor(|x| * 4/pi), round up to even
@@ -107,6 +112,9 @@ inline void fsincos_sse(double x, double &s, double &c)
 // fsincos_sse). cos is even: cos(-x) = cos(x), so no sign fixup needed.
 inline double fcos_sse(double x)
 {
+   if (__builtin_expect(!__builtin_isfinite(x), 0))
+      return __builtin_nan("");
+
    double abs_x = __builtin_fabs(x);
 
    // Find octant: j = floor(|x| * 4/pi), round up to even
@@ -154,7 +162,7 @@ inline double fcos_sse(double x)
 // x87 fsincos asm: ~2.4x faster than glibc sin()+cos().
 inline void fsincos_x87(double x, double &s, double &c)
 {
-   __asm__ ("fsincos;" : "=t" (c), "=u" (s) : "0" (x) : "st(7)");
+   __asm__ ("fsincos;" : "=t" (c), "=u" (s) : "0" (x));
 }
 
 inline void fsincos(double x, double &s, double &c)


### PR DESCRIPTION
## Summary
- Switch all CI jobs from `g++ -m32` (multilib) to `i686-linux-gnu-g++` cross-compiler toolchain, matching the local dev setup.
- Add `test-clang` and `sanitize-clang` CI jobs using `clang++ --target=i686-linux-gnu`.
- Fix clang compatibility issues: GCC-only Makefile flags made conditional, x87 asm clobber fix, NaN/inf UB in SSE math functions, function pointer type mismatch and unaligned read in tests.

## Test plan
- [x] GCC cross-compiler: `make test` passes locally
- [x] GCC cross-compiler: `make sanitize` passes locally
- [x] Clang cross-compiler: `make test` passes locally
- [x] Clang cross-compiler: `make sanitize` passes locally
- [x] CI: all jobs pass (test, sanitize, coverage, test-clang, sanitize-clang, build, package)