### PR TITLE
Replace -mincoming-stack-boundary=2 with per-function FORCE_STACK_ALIGN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ BASEFLAGS  = -Wall -Wno-write-strings $(VERFLAGS)
 BASEFLAGS += -fno-strict-aliasing -fno-strict-overflow
 BASEFLAGS += -fvisibility=hidden
 ifneq ($(COMPILER_IS_CLANG),1)
-BASEFLAGS += -Wno-class-memaccess -mincoming-stack-boundary=2
+BASEFLAGS += -Wno-class-memaccess
 endif
 ARCHFLAG  += $(TARGETFLAGS)
 

--- a/bot_func.h
+++ b/bot_func.h
@@ -67,9 +67,9 @@ void BotLookForDrop( bot_t &pBot );
 const cfg_bot_record_t * GetUnusedCfgBotRecord(void);
 void FreeCfgBotRecord(void);
 int AddToCfgBotRecord(const char *skin, const char *name, int skill, int top_color, int bottom_color);
-void ClientCommand( edict_t *pEntity );
+FORCE_STACK_ALIGN void ClientCommand( edict_t *pEntity );
 void FakeClientCommand(edict_t *pBot, const char *arg1, const char *arg2, const char *arg3);
-void jk_botti_ServerCommand(void);
+FORCE_STACK_ALIGN void jk_botti_ServerCommand(void);
 void ProcessBotCfgFile(void);
 
 // dll.cpp:

--- a/bot_query_hook.h
+++ b/bot_query_hook.h
@@ -1,6 +1,16 @@
 #ifndef BOT_QUERY_HOOK_H
 #define BOT_QUERY_HOOK_H
 
+// Duplicated from metamod/osdep.h — bot_query_hook files cannot include osdep.h
+// due to its heavy metamod/HL SDK header dependencies.
+#ifndef FORCE_STACK_ALIGN
+#if defined(__GNUC__) && defined(__i386__)
+   #define FORCE_STACK_ALIGN __attribute__((force_align_arg_pointer))
+#else
+   #define FORCE_STACK_ALIGN
+#endif
+#endif
+
 #ifdef _WIN32
    #define WIN32_LEAN_AND_MEAN
    #include <windows.h>

--- a/bot_query_hook_linux.cpp
+++ b/bot_query_hook_linux.cpp
@@ -77,7 +77,7 @@ inline void reset_sendto_hook(void)
 }
 
 // Replacement sendto function
-static ssize_t __replacement_sendto(int socket, const void *message, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len)
+static ssize_t FORCE_STACK_ALIGN __replacement_sendto(int socket, const void *message, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len)
 {
    return sendto_hook(socket, message, length, flags, dest_addr, dest_len);
 }

--- a/bot_query_hook_win32.cpp
+++ b/bot_query_hook_win32.cpp
@@ -67,7 +67,7 @@ inline void reset_sendto_hook(void)
 }
 
 // Replacement sendto function
-static ssize_t PASCAL __replacement_sendto(int socket, const void *message, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len)
+static ssize_t PASCAL FORCE_STACK_ALIGN __replacement_sendto(int socket, const void *message, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len)
 {
    return sendto_hook(socket, message, length, flags, dest_addr, dest_len);
 }

--- a/commands.cpp
+++ b/commands.cpp
@@ -922,7 +922,7 @@ static void print_to_client(int, void *arg, char *msg)
 }
 #endif
 
-void ClientCommand( edict_t *pEntity )
+FORCE_STACK_ALIGN void ClientCommand( edict_t *pEntity )
 {
    // only allow custom commands if deathmatch mode and NOT dedicated server and
    // client sending command is the listen server client...
@@ -1285,7 +1285,7 @@ static void print_to_server_output(int, void *, char * msg)
 }
 
 
-void jk_botti_ServerCommand (void)
+FORCE_STACK_ALIGN void jk_botti_ServerCommand (void)
 {
    if(FStrEq(CMD_ARGV(1), "kickall"))
    {

--- a/dll.cpp
+++ b/dll.cpp
@@ -174,7 +174,7 @@ static int CheckSubMod(void)
 }
 
 
-static void GameDLLInit( void )
+static FORCE_STACK_ALIGN void GameDLLInit( void )
 {
    //before anything else detect submod
    submod_id = CheckSubMod();
@@ -263,7 +263,7 @@ static void SpawnInitWorld(void)
 }
 
 
-static int Spawn( edict_t *pent )
+static FORCE_STACK_ALIGN int Spawn( edict_t *pent )
 {
    if (gpGlobals->deathmatch)
    {
@@ -331,7 +331,7 @@ static void SpawnPostHandleDoor(edict_t *pent)
 }
 
 
-static int Spawn_Post( edict_t *pent )
+static FORCE_STACK_ALIGN int Spawn_Post( edict_t *pent )
 {
    if(!gpGlobals->deathmatch)
       RETURN_META_VALUE (MRES_IGNORED, 0);
@@ -359,7 +359,7 @@ static int Spawn_Post( edict_t *pent )
 }
 
 
-static void DispatchKeyValue_Post( edict_t *pentKeyvalue, KeyValueData *pkvd )
+static FORCE_STACK_ALIGN void DispatchKeyValue_Post( edict_t *pentKeyvalue, KeyValueData *pkvd )
 {
    if(!gpGlobals->deathmatch)
       RETURN_META (MRES_IGNORED);
@@ -390,7 +390,7 @@ static void DispatchKeyValue_Post( edict_t *pentKeyvalue, KeyValueData *pkvd )
 }
 
 
-BOOL jkbotti_ClientConnect( edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[ 128 ] )
+FORCE_STACK_ALIGN BOOL jkbotti_ClientConnect( edict_t *pEntity, const char *pszName, const char *pszAddress, char szRejectReason[ 128 ] )
 {
    if (!gpGlobals->deathmatch)
       RETURN_META_VALUE (MRES_IGNORED, 0);
@@ -416,7 +416,7 @@ BOOL jkbotti_ClientConnect( edict_t *pEntity, const char *pszName, const char *p
 }
 
 
-void jkbotti_ClientPutInServer( edict_t *pEntity )
+FORCE_STACK_ALIGN void jkbotti_ClientPutInServer( edict_t *pEntity )
 {
    if (!gpGlobals->deathmatch)
       RETURN_META (MRES_IGNORED);
@@ -435,7 +435,7 @@ void jkbotti_ClientPutInServer( edict_t *pEntity )
 }
 
 
-static void CmdStart( const edict_t *player, const struct usercmd_s *cmd, unsigned int random_seed )
+static FORCE_STACK_ALIGN void CmdStart( const edict_t *player, const struct usercmd_s *cmd, unsigned int random_seed )
 {
    // check if is our bot
    int bot_index = UTIL_GetBotIndex(player);
@@ -474,7 +474,7 @@ static void CmdStart( const edict_t *player, const struct usercmd_s *cmd, unsign
 }
 
 
-static void ClientDisconnect( edict_t *pEntity )
+static FORCE_STACK_ALIGN void ClientDisconnect( edict_t *pEntity )
 {
    if (gpGlobals->deathmatch)
    {
@@ -503,7 +503,7 @@ static void ClientDisconnect( edict_t *pEntity )
 }
 
 
-static void ServerDeactivate(void)
+static FORCE_STACK_ALIGN void ServerDeactivate(void)
 {
    if(!gpGlobals->deathmatch)
       RETURN_META (MRES_IGNORED);
@@ -523,7 +523,7 @@ static void ServerDeactivate(void)
 }
 
 
-static void PlayerPostThink_Post( edict_t *pEdict )
+static FORCE_STACK_ALIGN void PlayerPostThink_Post( edict_t *pEdict )
 {
    if (!gpGlobals->deathmatch)
       RETURN_META(MRES_IGNORED);
@@ -541,7 +541,7 @@ static void PlayerPostThink_Post( edict_t *pEdict )
 }
 
 
-void new_PM_PlaySound(int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch)
+FORCE_STACK_ALIGN void new_PM_PlaySound(int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch)
 {
    if (gpGlobals->deathmatch)
    {
@@ -565,7 +565,7 @@ void new_PM_PlaySound(int channel, const char *sample, float volume, float atten
    (*old_PM_PlaySound)(channel, sample, volume, attenuation, fFlags, pitch);
 }
 
-static void PM_Move(struct playermove_s *ppmove, qboolean server)
+static FORCE_STACK_ALIGN void PM_Move(struct playermove_s *ppmove, qboolean server)
 {
    if (!gpGlobals->deathmatch)
       RETURN_META(MRES_IGNORED);
@@ -816,7 +816,7 @@ static void StartFrameManageBotCount(void)
 }
 
 
-static void StartFrame( void )
+static FORCE_STACK_ALIGN void StartFrame( void )
 {
    double begin_time;
    int count;
@@ -875,7 +875,7 @@ static void StartFrame( void )
 }
 
 
-C_DLLEXPORT int GetEntityAPI2 (DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion)
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI2 (DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion)
 {
    memset(pFunctionTable, 0, sizeof (DLL_FUNCTIONS));
 
@@ -893,7 +893,7 @@ C_DLLEXPORT int GetEntityAPI2 (DLL_FUNCTIONS *pFunctionTable, int *interfaceVers
    return (TRUE);
 }
 
-C_DLLEXPORT int GetEntityAPI2_POST (DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion)
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI2_POST (DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion)
 {
    memset(pFunctionTable, 0, sizeof (DLL_FUNCTIONS));
 
@@ -938,7 +938,7 @@ plugin_info_t Plugin_info = {
 };
 
 
-C_DLLEXPORT int Meta_Query (char *ifvers, plugin_info_t **pPlugInfo, mutil_funcs_t *pMetaUtilFuncs)
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Query (char *ifvers, plugin_info_t **pPlugInfo, mutil_funcs_t *pMetaUtilFuncs)
 {
    // this function is the first function ever called by metamod in the plugin DLL. Its purpose
    // is for metamod to retrieve basic information about the plugin, such as its meta-interface
@@ -987,7 +987,7 @@ C_DLLEXPORT int Meta_Query (char *ifvers, plugin_info_t **pPlugInfo, mutil_funcs
 }
 
 
-C_DLLEXPORT int Meta_Attach (PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, meta_globals_t *pMGlobals, gamedll_funcs_t *pGamedllFuncs)
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Attach (PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, meta_globals_t *pMGlobals, gamedll_funcs_t *pGamedllFuncs)
 {
    // this function is called when metamod attempts to load the plugin. Since it's the place
    // where we can tell if the plugin will be allowed to run or not, we wait until here to make
@@ -1025,7 +1025,7 @@ C_DLLEXPORT int Meta_Attach (PLUG_LOADTIME now, META_FUNCTIONS *pFunctionTable, 
 }
 
 
-C_DLLEXPORT int Meta_Detach (PLUG_LOADTIME now, PL_UNLOAD_REASON reason)
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Detach (PLUG_LOADTIME now, PL_UNLOAD_REASON reason)
 {
    // this function is called when metamod unloads the plugin. A basic check is made in order
    // to prevent unloading the plugin if its processing should not be interrupted.

--- a/engine.cpp
+++ b/engine.cpp
@@ -83,7 +83,7 @@ event_info_t g_event_info[] = {
 
 
 //
-static unsigned short pfnPrecacheEvent_Post(int type, const char* psz)
+static FORCE_STACK_ALIGN unsigned short pfnPrecacheEvent_Post(int type, const char* psz)
 {
    if (!gpGlobals->deathmatch)
       RETURN_META_VALUE (MRES_IGNORED, 0);
@@ -112,7 +112,7 @@ static unsigned short pfnPrecacheEvent_Post(int type, const char* psz)
 
 
 //
-static void pfnPlaybackEvent( int flags, const edict_t *pInvoker, unsigned short eventindex, float delay, float *origin, float *angles, float fparam1, float fparam2, int iparam1, int iparam2, int bparam1, int bparam2 )
+static FORCE_STACK_ALIGN void pfnPlaybackEvent( int flags, const edict_t *pInvoker, unsigned short eventindex, float delay, float *origin, float *angles, float fparam1, float fparam2, int iparam1, int iparam2, int bparam1, int bparam2 )
 {
    if (!gpGlobals->deathmatch)
       RETURN_META (MRES_IGNORED);
@@ -156,7 +156,7 @@ static void pfnPlaybackEvent( int flags, const edict_t *pInvoker, unsigned short
    RETURN_META (MRES_IGNORED);
 }
 
-static void pfnEmitSound(edict_t *entity, int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch)
+static FORCE_STACK_ALIGN void pfnEmitSound(edict_t *entity, int channel, const char *sample, float volume, float attenuation, int fFlags, int pitch)
 {
    if (gpGlobals->deathmatch && !FNullEnt(entity))
    {
@@ -181,7 +181,7 @@ static void pfnEmitSound(edict_t *entity, int channel, const char *sample, float
    RETURN_META (MRES_IGNORED);
 }
 
-static void pfnChangeLevel(char* s1, char* s2)
+static FORCE_STACK_ALIGN void pfnChangeLevel(char* s1, char* s2)
 {
    if (!gpGlobals->deathmatch)
       RETURN_META (MRES_IGNORED);
@@ -195,7 +195,7 @@ static void pfnChangeLevel(char* s1, char* s2)
 }
 
 
-static void pfnClientCommand(edict_t* pEdict, char* szFmt, ...)
+static FORCE_STACK_ALIGN void pfnClientCommand(edict_t* pEdict, char* szFmt, ...)
 {
    if (!FNullEnt(pEdict) && (FBitSet(pEdict->v.flags, FL_FAKECLIENT) || FBitSet(pEdict->v.flags, FL_THIRDPARTYBOT)))
       RETURN_META (MRES_SUPERCEDE);
@@ -208,7 +208,7 @@ static int FAST_GET_USER_MSG_ID(plid_t plindex, int & value, const char * name, 
    return(value ? value : (value = GET_USER_MSG_ID(plindex, name, size)));
 }
 
-static void pfnMessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *ed)
+static FORCE_STACK_ALIGN void pfnMessageBegin(int msg_dest, int msg_type, const float *pOrigin, edict_t *ed)
 {
    if (gpGlobals->deathmatch)
    {
@@ -302,7 +302,7 @@ static void pfnMessageBegin(int msg_dest, int msg_type, const float *pOrigin, ed
 }
 
 
-static void pfnMessageEnd(void)
+static FORCE_STACK_ALIGN void pfnMessageEnd(void)
 {
    if (gpGlobals->deathmatch)
    {
@@ -318,7 +318,7 @@ static void pfnMessageEnd(void)
 }
 
 
-static void pfnWriteByte(int iValue)
+static FORCE_STACK_ALIGN void pfnWriteByte(int iValue)
 {
    if (gpGlobals->deathmatch)
    {
@@ -331,7 +331,7 @@ static void pfnWriteByte(int iValue)
 }
 
 
-static void pfnWriteChar(int iValue)
+static FORCE_STACK_ALIGN void pfnWriteChar(int iValue)
 {
    if (gpGlobals->deathmatch)
    {
@@ -344,7 +344,7 @@ static void pfnWriteChar(int iValue)
 }
 
 
-static void pfnWriteShort(int iValue)
+static FORCE_STACK_ALIGN void pfnWriteShort(int iValue)
 {
    if (gpGlobals->deathmatch)
    {
@@ -357,7 +357,7 @@ static void pfnWriteShort(int iValue)
 }
 
 
-static void pfnWriteLong(int iValue)
+static FORCE_STACK_ALIGN void pfnWriteLong(int iValue)
 {
    if (gpGlobals->deathmatch)
    {
@@ -370,7 +370,7 @@ static void pfnWriteLong(int iValue)
 }
 
 
-static void pfnWriteAngle(float flValue)
+static FORCE_STACK_ALIGN void pfnWriteAngle(float flValue)
 {
    if (gpGlobals->deathmatch)
    {
@@ -383,7 +383,7 @@ static void pfnWriteAngle(float flValue)
 }
 
 
-static void pfnWriteCoord(float flValue)
+static FORCE_STACK_ALIGN void pfnWriteCoord(float flValue)
 {
    if (gpGlobals->deathmatch)
    {
@@ -396,7 +396,7 @@ static void pfnWriteCoord(float flValue)
 }
 
 
-static void pfnWriteString(const char *sz)
+static FORCE_STACK_ALIGN void pfnWriteString(const char *sz)
 {
    if (gpGlobals->deathmatch)
    {
@@ -409,7 +409,7 @@ static void pfnWriteString(const char *sz)
 }
 
 
-static void pfnWriteEntity(int iValue)
+static FORCE_STACK_ALIGN void pfnWriteEntity(int iValue)
 {
    if (gpGlobals->deathmatch)
    {
@@ -422,7 +422,7 @@ static void pfnWriteEntity(int iValue)
 }
 
 
-static void pfnClientPrintf( edict_t* pEdict, PRINT_TYPE ptype, const char *szMsg )
+static FORCE_STACK_ALIGN void pfnClientPrintf( edict_t* pEdict, PRINT_TYPE ptype, const char *szMsg )
 {
    if (!FNullEnt(pEdict) && (FBitSet(pEdict->v.flags, FL_FAKECLIENT) || FBitSet(pEdict->v.flags, FL_THIRDPARTYBOT)))
       RETURN_META (MRES_SUPERCEDE);
@@ -431,7 +431,7 @@ static void pfnClientPrintf( edict_t* pEdict, PRINT_TYPE ptype, const char *szMs
 }
 
 
-static const char *pfnCmd_Args( void )
+static FORCE_STACK_ALIGN const char *pfnCmd_Args( void )
 {
    if (isFakeClientCommand)
       RETURN_META_VALUE (MRES_SUPERCEDE, &g_argv[0]);
@@ -440,7 +440,7 @@ static const char *pfnCmd_Args( void )
 }
 
 
-static const char *pfnCmd_Argv( int argc )
+static FORCE_STACK_ALIGN const char *pfnCmd_Argv( int argc )
 {
    if (isFakeClientCommand)
    {
@@ -458,7 +458,7 @@ static const char *pfnCmd_Argv( int argc )
 }
 
 
-static int pfnCmd_Argc( void )
+static FORCE_STACK_ALIGN int pfnCmd_Argc( void )
 {
    if (isFakeClientCommand)
       RETURN_META_VALUE (MRES_SUPERCEDE, fake_arg_count);
@@ -467,7 +467,7 @@ static int pfnCmd_Argc( void )
 }
 
 
-static void pfnSetClientMaxspeed(const edict_t *pEdict, float fNewMaxspeed)
+static FORCE_STACK_ALIGN void pfnSetClientMaxspeed(const edict_t *pEdict, float fNewMaxspeed)
 {
    if (!gpGlobals->deathmatch)
       RETURN_META (MRES_IGNORED);
@@ -484,7 +484,7 @@ static void pfnSetClientMaxspeed(const edict_t *pEdict, float fNewMaxspeed)
 }
 
 
-static int pfnGetPlayerUserId(edict_t *e )
+static FORCE_STACK_ALIGN int pfnGetPlayerUserId(edict_t *e )
 {
    if (gpGlobals->deathmatch)
    {
@@ -500,7 +500,7 @@ static int pfnGetPlayerUserId(edict_t *e )
 }
 
 
-C_DLLEXPORT int GetEngineFunctions (enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion)
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEngineFunctions (enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion)
 {
    memset(pengfuncsFromEngine, 0, sizeof(enginefuncs_t));
 
@@ -529,7 +529,7 @@ C_DLLEXPORT int GetEngineFunctions (enginefuncs_t *pengfuncsFromEngine, int *int
 }
 
 
-C_DLLEXPORT int GetEngineFunctions_POST (enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion)
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEngineFunctions_POST (enginefuncs_t *pengfuncsFromEngine, int *interfaceVersion)
 {
    memset(pengfuncsFromEngine, 0, sizeof(enginefuncs_t));
 

--- a/h_export.cpp
+++ b/h_export.cpp
@@ -28,7 +28,7 @@ extern "C" BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvRe
 
 #endif
 
-void WINAPI GiveFnptrsToDll( enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals )
+FORCE_STACK_ALIGN void WINAPI GiveFnptrsToDll( enginefuncs_t* pengfuncsFromEngine, globalvars_t *pGlobals )
 {
    // get the engine functions from the engine...
    memcpy(&g_engfuncs, pengfuncsFromEngine, sizeof(enginefuncs_t));

--- a/metamod/osdep.h
+++ b/metamod/osdep.h
@@ -86,6 +86,14 @@
 // DLLEXPORT is defined, for convenience.
 #define C_DLLEXPORT		extern "C" DLLEXPORT
 
+// On 32-bit x86, the HL engine may call functions with only 4-byte stack
+// alignment. Apply this to entry points called by engine/gamedll/plugins.
+#if defined(__GNUC__) && defined(__i386__)
+	#define FORCE_STACK_ALIGN __attribute__((force_align_arg_pointer))
+#else
+	#define FORCE_STACK_ALIGN
+#endif
+
 
 #ifdef _MSC_VER
 	// Disable MSVC warning:


### PR DESCRIPTION
## Summary
- Remove the global `-mincoming-stack-boundary=2` compiler flag which pessimized all code for the sake of engine entry points
- Add `FORCE_STACK_ALIGN` macro (`__attribute__((force_align_arg_pointer))`) in `metamod/osdep.h`, matching metamod-p's approach
- Apply `FORCE_STACK_ALIGN` to all functions whose pointers are written to externally-accessible memory (engine callbacks, metamod API, DLL_FUNCTIONS tables, PM_Move hooks, REG_SVR_COMMAND callbacks, sendto JMP hooks)

## Test plan
- [x] CI passes (GCC + clang, test + sanitize)
- [x] Verify no function pointer entry points were missed by grepping for `pfn*`, `REG_SVR_COMMAND`, function pointer assignments