### PR TITLE
Fix metamod meta cvars showing (unknown) for shim plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,16 +188,14 @@ CXXFLAGS += $(CFLAGS)
 .PHONY: _build _test _valgrind _sanitize _coverage _depend
 
 # ----------------------------------------------------------------------------
-# Shim variant: single-file forwarder, no zlib, no HL SDK headers.
+# Shim variant: single-file forwarder, no zlib.
 # ----------------------------------------------------------------------------
 ifeq ($(VARIANT),shim)
 
-SHIM_CFLAGS = -Wall -Wextra -Wno-unused-parameter $(OPTFLAGS) $(ARCHFLAG) -std=gnu99
-
 _build: $(OUTPUT)
 
-$(OUTPUT): shim.c | $(OBJDIR)
-	$(CC) $(SHIM_CFLAGS) -o $@ $< $(LINKFLAGS)
+$(OUTPUT): shim.cpp | $(OBJDIR)
+	$(CXX) $(CXXFLAGS) -o $@ $< $(LINKFLAGS)
 	mkdir -p addons/jk_botti/dlls
 	cp $@ addons/jk_botti/dlls/
 ifneq ($(OSTYPE),win32)

--- a/shim.cpp
+++ b/shim.cpp
@@ -9,33 +9,16 @@
  * runs before we have proven the CPU supports those instruction sets.
  */
 
-#ifndef _WIN32
-#  define _GNU_SOURCE  /* Dl_info, dladdr */
-#endif
-
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 #ifndef SHIM_TEST
-#  include <cpuid.h>
+#include <cpuid.h>
 #endif
 
-#ifdef _WIN32
-#  define WIN32_LEAN_AND_MEAN
-#  include <windows.h>
-#  ifdef SHIM_TEST
-#     define DLLEXPORT
-#     define WINAPI_
-#  else
-#     define DLLEXPORT __declspec(dllexport)
-#     define WINAPI_   __stdcall
-#  endif
-#else
-#  include <dlfcn.h>
-#  define DLLEXPORT __attribute__((visibility("default")))
-#  define WINAPI_
-#endif
+#include <extdll.h>
+#include <dllapi.h>
+#include <h_export.h>
+#include <meta_api.h>
 
 /* ---- variant filenames (siblings in the shim's own directory) ---------- */
 
@@ -100,11 +83,9 @@ int has_sse3(void);
 
 /* ---- dlopen / LoadLibrary abstraction ---------------------------------- */
 
-#ifdef _WIN32
-typedef HMODULE dl_handle_t;
-#else
-typedef void   *dl_handle_t;
-#endif
+typedef void *dl_handle_t;
+
+#ifndef SHIM_TEST
 
 static dl_handle_t dl_open(const char *path, char *errbuf, size_t errcap)
 {
@@ -113,7 +94,7 @@ static dl_handle_t dl_open(const char *path, char *errbuf, size_t errcap)
    if (!h)
       snprintf(errbuf, errcap, "LoadLibrary(%s) failed, GetLastError=%lu",
                path, (unsigned long)GetLastError());
-   return h;
+   return (dl_handle_t)h;
 #else
    void *h = dlopen(path, RTLD_NOW | RTLD_LOCAL);
    if (!h) {
@@ -127,7 +108,7 @@ static dl_handle_t dl_open(const char *path, char *errbuf, size_t errcap)
 static void *dl_sym(dl_handle_t h, const char *name)
 {
 #ifdef _WIN32
-   return (void *)GetProcAddress(h, name);
+   return (void *)GetProcAddress((HMODULE)h, name);
 #else
    return dlsym(h, name);
 #endif
@@ -136,30 +117,93 @@ static void *dl_sym(dl_handle_t h, const char *name)
 static void dl_close(dl_handle_t h)
 {
 #ifdef _WIN32
-   FreeLibrary(h);
+   FreeLibrary((HMODULE)h);
 #else
    dlclose(h);
 #endif
 }
 
+#else /* SHIM_TEST: provided by test harness */
+
+dl_handle_t dl_open(const char *path, char *errbuf, size_t errcap);
+void *dl_sym(dl_handle_t h, const char *name);
+void dl_close(dl_handle_t h);
+
+#endif
+
+/* ---- Metamod plugin ownership proxy ----------------------------------- */
+/*
+ * Metamod identifies which plugin owns a cvar/command by calling dladdr()
+ * on the cvar_t pointer or command-handler function pointer.  Since the
+ * shim loads the variant with dlopen(), those addresses resolve to the
+ * variant .so, not the shim .so that metamod actually loaded.  The fix:
+ * intercept pfnCVarRegister and pfnAddServerCommand in the engine function
+ * table, copying data into shim-local storage so dladdr() resolves to us.
+ */
+
+typedef __typeof__(((enginefuncs_t*)NULL)->pfnCVarRegister) pfn_CVarRegister_t;
+typedef __typeof__(((enginefuncs_t*)NULL)->pfnAddServerCommand) pfn_AddServerCommand_t;
+
+#define MAX_PROXY_CVARS 8
+static cvar_t g_proxy_cvars[MAX_PROXY_CVARS];
+static int g_proxy_cvar_count;
+static pfn_CVarRegister_t g_real_CVarRegister;
+
+#define MAX_PROXY_CMDS 4
+static void (*g_proxy_cmd_targets[MAX_PROXY_CMDS])(void);
+
+static void FORCE_STACK_ALIGN proxy_cmd_handler_0(void) { if (g_proxy_cmd_targets[0]) g_proxy_cmd_targets[0](); }
+static void FORCE_STACK_ALIGN proxy_cmd_handler_1(void) { if (g_proxy_cmd_targets[1]) g_proxy_cmd_targets[1](); }
+static void FORCE_STACK_ALIGN proxy_cmd_handler_2(void) { if (g_proxy_cmd_targets[2]) g_proxy_cmd_targets[2](); }
+static void FORCE_STACK_ALIGN proxy_cmd_handler_3(void) { if (g_proxy_cmd_targets[3]) g_proxy_cmd_targets[3](); }
+
+typedef void (*pfn_void_void)(void);
+static const pfn_void_void g_proxy_cmd_handlers[MAX_PROXY_CMDS] = {
+   proxy_cmd_handler_0, proxy_cmd_handler_1,
+   proxy_cmd_handler_2, proxy_cmd_handler_3,
+};
+static int g_proxy_cmd_count;
+static pfn_AddServerCommand_t g_real_AddServerCommand;
+
+static void FORCE_STACK_ALIGN shim_CVarRegister(cvar_t *pCvar)
+{
+   if (!g_real_CVarRegister)
+      return;
+   if (g_proxy_cvar_count < MAX_PROXY_CVARS) {
+      cvar_t *local = &g_proxy_cvars[g_proxy_cvar_count++];
+      *local = *pCvar;
+      g_real_CVarRegister(local);
+   } else {
+      g_real_CVarRegister(pCvar);
+   }
+}
+
+static void FORCE_STACK_ALIGN shim_AddServerCommand(char *cmd_name, void (*function)(void))
+{
+   if (!g_real_AddServerCommand)
+      return;
+   if (g_proxy_cmd_count < MAX_PROXY_CMDS) {
+      int idx = g_proxy_cmd_count++;
+      g_proxy_cmd_targets[idx] = function;
+      g_real_AddServerCommand(cmd_name, g_proxy_cmd_handlers[idx]);
+   } else {
+      g_real_AddServerCommand(cmd_name, function);
+   }
+}
+
+static enginefuncs_t g_engfuncs_copy;
+
 /* ---- forward-declaration of variant entry points ----------------------- */
 
-typedef void (WINAPI_ *pfn_GiveFnptrsToDll)(void *, void *);
-typedef int  (*pfn_Meta_Query)(char *, void **, void *);
-typedef int  (*pfn_Meta_Attach)(int, void *, void *, void *);
-typedef int  (*pfn_Meta_Detach)(int, int);
-typedef int  (*pfn_EntityAPI)(void *, int *);
-typedef int  (*pfn_EngineAPI)(void *, int *);
-
-static dl_handle_t          g_variant;
-static pfn_GiveFnptrsToDll  p_GiveFnptrsToDll;
-static pfn_Meta_Query       p_Meta_Query;
-static pfn_Meta_Attach      p_Meta_Attach;
-static pfn_Meta_Detach      p_Meta_Detach;
-static pfn_EntityAPI        p_GetEntityAPI2;
-static pfn_EntityAPI        p_GetEntityAPI2_POST;
-static pfn_EngineAPI        p_GetEngineFunctions;
-static pfn_EngineAPI        p_GetEngineFunctions_POST;
+static dl_handle_t              g_variant;
+static GIVE_ENGINE_FUNCTIONS_FN p_GiveFnptrsToDll;
+static META_QUERY_FN            p_Meta_Query;
+static META_ATTACH_FN           p_Meta_Attach;
+static META_DETACH_FN           p_Meta_Detach;
+static GETENTITYAPI2_FN         p_GetEntityAPI2;
+static GETENTITYAPI2_FN         p_GetEntityAPI2_POST;
+static GET_ENGINE_FUNCTIONS_FN  p_GetEngineFunctions;
+static GET_ENGINE_FUNCTIONS_FN  p_GetEngineFunctions_POST;
 
 /* ---- self path resolution ---------------------------------------------- */
 
@@ -329,61 +373,77 @@ static int ensure_loaded(void)
 
 /* ---- exported Metamod entry points ------------------------------------- */
 
-DLLEXPORT void WINAPI_ GiveFnptrsToDll(void *pengfuncsFromEngine,
-                                       void *pGlobals)
+C_DLLEXPORT FORCE_STACK_ALIGN void WINAPI GiveFnptrsToDll(enginefuncs_t *pengfuncsFromEngine,
+							  globalvars_t *pGlobals)
 {
    if (!ensure_loaded())
       return;
-   p_GiveFnptrsToDll(pengfuncsFromEngine, pGlobals);
+
+   g_engfuncs_copy = *pengfuncsFromEngine;
+
+   g_real_CVarRegister = (pfn_CVarRegister_t)g_engfuncs_copy.pfnCVarRegister;
+   g_engfuncs_copy.pfnCVarRegister = shim_CVarRegister;
+   g_engfuncs_copy.pfnCvar_RegisterVariable = shim_CVarRegister;
+
+   g_real_AddServerCommand = (pfn_AddServerCommand_t)g_engfuncs_copy.pfnAddServerCommand;
+   g_engfuncs_copy.pfnAddServerCommand = shim_AddServerCommand;
+
+   p_GiveFnptrsToDll(&g_engfuncs_copy, pGlobals);
 }
 
-DLLEXPORT int Meta_Query(char *ifvers, void **pPlugInfo,
-                         void *pMetaUtilFuncs)
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Query(char *interfaceVersion,
+					     plugin_info_t **plinfo,
+					     mutil_funcs_t *pMetaUtilFuncs)
 {
    if (!ensure_loaded())
       return 0;
-   return p_Meta_Query(ifvers, pPlugInfo, pMetaUtilFuncs);
+   return p_Meta_Query(interfaceVersion, plinfo, pMetaUtilFuncs);
 }
 
-DLLEXPORT int Meta_Attach(int now, void *pFunctionTable,
-                          void *pMGlobals, void *pGamedllFuncs)
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Attach(PLUG_LOADTIME now,
+					      META_FUNCTIONS *pFunctionTable,
+					      meta_globals_t *pMGlobals,
+					      gamedll_funcs_t *pGamedllFuncs)
 {
    if (!ensure_loaded())
       return 0;
    return p_Meta_Attach(now, pFunctionTable, pMGlobals, pGamedllFuncs);
 }
 
-DLLEXPORT int Meta_Detach(int now, int reason)
+C_DLLEXPORT FORCE_STACK_ALIGN int Meta_Detach(PLUG_LOADTIME now,
+					      PL_UNLOAD_REASON reason)
 {
    if (!g_init_ok)
       return 1;
    return p_Meta_Detach(now, reason);
 }
 
-DLLEXPORT int GetEntityAPI2(void *pFunctionTable, int *interfaceVersion)
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable,
+						int *interfaceVersion)
 {
    if (!ensure_loaded())
       return 0;
    return p_GetEntityAPI2(pFunctionTable, interfaceVersion);
 }
 
-DLLEXPORT int GetEntityAPI2_POST(void *pFunctionTable, int *interfaceVersion)
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEntityAPI2_POST(DLL_FUNCTIONS *pFunctionTable,
+						     int *interfaceVersion)
 {
    if (!ensure_loaded())
       return 0;
    return p_GetEntityAPI2_POST(pFunctionTable, interfaceVersion);
 }
 
-DLLEXPORT int GetEngineFunctions(void *pengfuncsFromEngine,
-                                 int *interfaceVersion)
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEngineFunctions(enginefuncs_t *pengfuncsFromEngine,
+						     int *interfaceVersion)
 {
    if (!ensure_loaded())
       return 0;
    return p_GetEngineFunctions(pengfuncsFromEngine, interfaceVersion);
 }
 
-DLLEXPORT int GetEngineFunctions_POST(void *pengfuncsFromEngine,
-                                      int *interfaceVersion)
+C_DLLEXPORT FORCE_STACK_ALIGN int GetEngineFunctions_POST(enginefuncs_t *pengfuncsFromEngine,
+							  int *interfaceVersion)
 {
    if (!ensure_loaded())
       return 0;
@@ -391,7 +451,7 @@ DLLEXPORT int GetEngineFunctions_POST(void *pengfuncsFromEngine,
 }
 
 #if defined(_WIN32) && !defined(SHIM_TEST)
-BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved)
+FORCE_STACK_ALIGN BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID reserved)
 {
    (void)hinst; (void)reason; (void)reserved;
    return TRUE;
@@ -413,9 +473,27 @@ void shim_test_reset(void)
    p_GetEntityAPI2_POST = NULL;
    p_GetEngineFunctions = NULL;
    p_GetEngineFunctions_POST = NULL;
+   g_real_CVarRegister = NULL;
+   g_real_AddServerCommand = NULL;
+   g_proxy_cvar_count = 0;
+   g_proxy_cmd_count = 0;
+   memset(g_proxy_cvars, 0, sizeof(g_proxy_cvars));
+   memset(g_proxy_cmd_targets, 0, sizeof(g_proxy_cmd_targets));
+   memset(&g_engfuncs_copy, 0, sizeof(g_engfuncs_copy));
 }
 
 int shim_test_ensure_loaded(void)             { return ensure_loaded(); }
 int shim_test_load_variant(const char *dir,
                            const char *leaf)  { return load_variant(dir, leaf); }
+
+/* Proxy test accessors */
+cvar_t *shim_test_get_proxy_cvar(int idx)     { return &g_proxy_cvars[idx]; }
+int shim_test_get_proxy_cvar_count(void)      { return g_proxy_cvar_count; }
+int shim_test_get_proxy_cmd_count(void)       { return g_proxy_cmd_count; }
+pfn_void_void shim_test_get_proxy_cmd_handler(int idx) { return g_proxy_cmd_handlers[idx]; }
+void shim_test_call_CVarRegister(cvar_t *cv)  { shim_CVarRegister(cv); }
+void shim_test_call_AddServerCommand(char *name, void (*fn)(void)) { shim_AddServerCommand(name, fn); }
+void shim_test_set_real_CVarRegister(pfn_CVarRegister_t fn) { g_real_CVarRegister = fn; }
+void shim_test_set_real_AddServerCommand(pfn_AddServerCommand_t fn) { g_real_AddServerCommand = fn; }
+enginefuncs_t *shim_test_get_engfuncs_copy(void) { return &g_engfuncs_copy; }
 #endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -192,12 +192,14 @@ test_bot_query_hook_win32.o: test_bot_query_hook_win32.cpp ../bot_query_hook_win
 test_bot_query_hook_win32: test_bot_query_hook_win32.o
 	${CXX} $(COVERAGE_FLAGS) -o $@ test_bot_query_hook_win32.o
 
-# shim tests (shim.c #included with -D_WIN32 -DSHIM_TEST, mock Win32 headers)
-test_shim.o: test_shim.cpp ../shim.c windows.h
-	${CXX} -Wall -D_WIN32 -DSHIM_TEST -I. -I".." $(COVERAGE_FLAGS) -c $< -o $@
+# shim tests (shim.cpp #included with -DSHIM_TEST)
+test_shim.o: test_shim.cpp ../shim.cpp
+	${CXX} ${TEST_CXXFLAGS} -DSHIM_TEST -c $< -o $@
 
-test_shim: test_shim.o
-	${CXX} $(COVERAGE_FLAGS) -o $@ test_shim.o
+SHIM_OBJS = engine_mock.o test_shim.o util.o safe_snprintf.o random_num.o
+
+test_shim: $(SHIM_OBJS)
+	${CXX} $(COVERAGE_FLAGS) -o $@ $(SHIM_OBJS) -lm
 
 BOT_TRACE_OBJS = engine_mock.o test_bot_trace.o \
 	bot_trace.o bot_weapons.o util.o safe_snprintf.o random_num.o

--- a/tests/test_shim.cpp
+++ b/tests/test_shim.cpp
@@ -1,14 +1,10 @@
 //
-// JK_Botti - tests for shim.c
+// JK_Botti - tests for shim.cpp
 //
-// Compiles shim.c as the Win32 variant on Linux, mocking LoadLibraryA /
-// GetProcAddress / OutputDebugStringA and the CPU-feature detection helpers.
-// Build with: -D_WIN32 -DSHIM_TEST -I. (tests dir for mock windows.h)
+// Tests the CPU dispatch and variant loading logic by mocking
+// dl_open/dl_sym/dl_close and the CPU detection helpers.
+// Build with: -DSHIM_TEST
 //
-
-#ifndef _WIN32
-#define _WIN32
-#endif
 
 #include <stdlib.h>
 #include <string.h>
@@ -16,7 +12,7 @@
 #include <map>
 #include <vector>
 
-#include "../shim.c"
+#include "../shim.cpp"
 
 #include "test_common.h"
 
@@ -31,13 +27,13 @@ struct MockLib {
 
 static std::map<std::string, MockLib> mock_libs;
 static std::vector<std::string>       load_attempts;
-static std::vector<MockLib *>         free_attempts;
+static std::vector<MockLib *>         close_attempts;
 static int mock_has_avx2_fma_val = 0;
 static int mock_has_sse3_val     = 0;
 static std::string mock_self_dir = "/mock/";
 
 // ============================================================
-// Mocks of shim.c externals (has_avx2_fma / has_sse3 / self_directory)
+// Mocks of shim.cpp externals (has_avx2_fma / has_sse3 / self_directory)
 // ============================================================
 
 int has_avx2_fma(void) { return mock_has_avx2_fma_val; }
@@ -52,38 +48,34 @@ int self_directory(char *out, size_t cap)
 }
 
 // ============================================================
-// Mock Win32 API implementations
+// Mock dl_open / dl_sym / dl_close
 // ============================================================
 
-HMODULE LoadLibraryA(const char *name)
+dl_handle_t dl_open(const char *path, char *errbuf, size_t errcap)
 {
-   load_attempts.push_back(name);
-   auto it = mock_libs.find(name);
-   if (it == mock_libs.end() || !it->second.load_ok)
+   load_attempts.push_back(path);
+   auto it = mock_libs.find(path);
+   if (it == mock_libs.end() || !it->second.load_ok) {
+      snprintf(errbuf, errcap, "mock: load failed for %s", path);
       return NULL;
-   return reinterpret_cast<HMODULE>(&it->second);
+   }
+   return reinterpret_cast<dl_handle_t>(&it->second);
 }
 
-FARPROC GetProcAddress(HMODULE module, const char *name)
+void *dl_sym(dl_handle_t h, const char *name)
 {
    (void)name;
-   MockLib *lib = reinterpret_cast<MockLib *>(module);
+   MockLib *lib = reinterpret_cast<MockLib *>(h);
    if (!lib || !lib->have_all_syms)
       return NULL;
-   // Non-null sentinel address — shim stores it into its function-pointer slot
-   // but never calls through during these tests.
    static int fake;
-   return reinterpret_cast<FARPROC>(&fake);
+   return reinterpret_cast<void *>(&fake);
 }
 
-BOOL FreeLibrary(HMODULE module)
+void dl_close(dl_handle_t h)
 {
-   free_attempts.push_back(reinterpret_cast<MockLib *>(module));
-   return 1;
+   close_attempts.push_back(reinterpret_cast<MockLib *>(h));
 }
-
-DWORD GetLastError(void) { return 0; }
-void OutputDebugStringA(const char *msg) { (void)msg; }
 
 // ============================================================
 // Helpers
@@ -94,11 +86,17 @@ static void reset_all(void)
    shim_test_reset();
    mock_libs.clear();
    load_attempts.clear();
-   free_attempts.clear();
+   close_attempts.clear();
    mock_has_avx2_fma_val = 0;
    mock_has_sse3_val     = 0;
    mock_self_dir         = "/mock/";
 }
+
+#ifdef _WIN32
+#define VARIANT_EXT ".dll"
+#else
+#define VARIANT_EXT "_i386.so"
+#endif
 
 static void add_lib(const char *leaf, bool load_ok, bool have_all_syms)
 {
@@ -116,15 +114,15 @@ static int test_picks_avx2fma_when_available(void)
 {
    TEST("ensure_loaded picks avx2fma when available");
    reset_all();
-   add_lib("jk_botti_mm_avx2fma.dll", true, true);
-   add_lib("jk_botti_mm_sse3.dll",    true, true);
-   add_lib("jk_botti_mm_x87.dll",     true, true);
+   add_lib("jk_botti_mm_avx2fma" VARIANT_EXT, true, true);
+   add_lib("jk_botti_mm_sse3" VARIANT_EXT,    true, true);
+   add_lib("jk_botti_mm_x87" VARIANT_EXT,     true, true);
    mock_has_avx2_fma_val = 1;
    mock_has_sse3_val     = 1;
 
    ASSERT_INT(shim_test_ensure_loaded(), 1);
    ASSERT_INT((int)load_attempts.size(), 1);
-   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_avx2fma.dll");
+   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_avx2fma" VARIANT_EXT);
    PASS();
    return 0;
 }
@@ -133,14 +131,14 @@ static int test_picks_sse3_when_no_avx2(void)
 {
    TEST("ensure_loaded picks sse3 when avx2 unavailable");
    reset_all();
-   add_lib("jk_botti_mm_sse3.dll", true, true);
-   add_lib("jk_botti_mm_x87.dll",  true, true);
+   add_lib("jk_botti_mm_sse3" VARIANT_EXT, true, true);
+   add_lib("jk_botti_mm_x87" VARIANT_EXT,  true, true);
    mock_has_avx2_fma_val = 0;
    mock_has_sse3_val     = 1;
 
    ASSERT_INT(shim_test_ensure_loaded(), 1);
    ASSERT_INT((int)load_attempts.size(), 1);
-   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_sse3.dll");
+   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_sse3" VARIANT_EXT);
    PASS();
    return 0;
 }
@@ -149,13 +147,13 @@ static int test_picks_x87_when_no_sse3(void)
 {
    TEST("ensure_loaded picks x87 when sse3 unavailable");
    reset_all();
-   add_lib("jk_botti_mm_x87.dll", true, true);
+   add_lib("jk_botti_mm_x87" VARIANT_EXT, true, true);
    mock_has_avx2_fma_val = 0;
    mock_has_sse3_val     = 0;
 
    ASSERT_INT(shim_test_ensure_loaded(), 1);
    ASSERT_INT((int)load_attempts.size(), 1);
-   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_x87.dll");
+   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_x87" VARIANT_EXT);
    PASS();
    return 0;
 }
@@ -164,16 +162,16 @@ static int test_fallback_avx2_load_fails(void)
 {
    TEST("ensure_loaded falls back sse3 when avx2 load fails");
    reset_all();
-   add_lib("jk_botti_mm_avx2fma.dll", false, false);  // load fails
-   add_lib("jk_botti_mm_sse3.dll",    true,  true);
-   add_lib("jk_botti_mm_x87.dll",     true,  true);
+   add_lib("jk_botti_mm_avx2fma" VARIANT_EXT, false, false);
+   add_lib("jk_botti_mm_sse3" VARIANT_EXT,    true,  true);
+   add_lib("jk_botti_mm_x87" VARIANT_EXT,     true,  true);
    mock_has_avx2_fma_val = 1;
    mock_has_sse3_val     = 1;
 
    ASSERT_INT(shim_test_ensure_loaded(), 1);
    ASSERT_INT((int)load_attempts.size(), 2);
-   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_avx2fma.dll");
-   ASSERT_STR(load_attempts[1].c_str(), "/mock/jk_botti_mm_sse3.dll");
+   ASSERT_STR(load_attempts[0].c_str(), "/mock/jk_botti_mm_avx2fma" VARIANT_EXT);
+   ASSERT_STR(load_attempts[1].c_str(), "/mock/jk_botti_mm_sse3" VARIANT_EXT);
    PASS();
    return 0;
 }
@@ -182,15 +180,15 @@ static int test_fallback_missing_symbols(void)
 {
    TEST("ensure_loaded falls back when symbol missing");
    reset_all();
-   add_lib("jk_botti_mm_avx2fma.dll", true,  false); // loads but missing syms
-   add_lib("jk_botti_mm_sse3.dll",    true,  true);
-   add_lib("jk_botti_mm_x87.dll",     true,  true);
+   add_lib("jk_botti_mm_avx2fma" VARIANT_EXT, true,  false);
+   add_lib("jk_botti_mm_sse3" VARIANT_EXT,    true,  true);
+   add_lib("jk_botti_mm_x87" VARIANT_EXT,     true,  true);
    mock_has_avx2_fma_val = 1;
    mock_has_sse3_val     = 1;
 
    ASSERT_INT(shim_test_ensure_loaded(), 1);
    ASSERT_INT((int)load_attempts.size(), 2);
-   ASSERT_STR(load_attempts[1].c_str(), "/mock/jk_botti_mm_sse3.dll");
+   ASSERT_STR(load_attempts[1].c_str(), "/mock/jk_botti_mm_sse3" VARIANT_EXT);
    PASS();
    return 0;
 }
@@ -199,15 +197,15 @@ static int test_all_fall_back_to_x87(void)
 {
    TEST("ensure_loaded falls through avx2->sse3->x87");
    reset_all();
-   add_lib("jk_botti_mm_avx2fma.dll", false, false);
-   add_lib("jk_botti_mm_sse3.dll",    false, false);
-   add_lib("jk_botti_mm_x87.dll",     true,  true);
+   add_lib("jk_botti_mm_avx2fma" VARIANT_EXT, false, false);
+   add_lib("jk_botti_mm_sse3" VARIANT_EXT,    false, false);
+   add_lib("jk_botti_mm_x87" VARIANT_EXT,     true,  true);
    mock_has_avx2_fma_val = 1;
    mock_has_sse3_val     = 1;
 
    ASSERT_INT(shim_test_ensure_loaded(), 1);
    ASSERT_INT((int)load_attempts.size(), 3);
-   ASSERT_STR(load_attempts[2].c_str(), "/mock/jk_botti_mm_x87.dll");
+   ASSERT_STR(load_attempts[2].c_str(), "/mock/jk_botti_mm_x87" VARIANT_EXT);
    PASS();
    return 0;
 }
@@ -229,8 +227,8 @@ static int test_init_is_sticky(void)
 {
    TEST("ensure_loaded returns cached result on second call");
    reset_all();
-   add_lib("jk_botti_mm_sse3.dll", true, true);
-   add_lib("jk_botti_mm_x87.dll",  true, true);
+   add_lib("jk_botti_mm_sse3" VARIANT_EXT, true, true);
+   add_lib("jk_botti_mm_x87" VARIANT_EXT,  true, true);
    mock_has_avx2_fma_val = 0;
    mock_has_sse3_val     = 1;
 
@@ -248,9 +246,9 @@ static int test_load_variant_direct_ok(void)
 {
    TEST("load_variant succeeds when library + symbols present");
    reset_all();
-   add_lib("jk_botti_mm_sse3.dll", true, true);
+   add_lib("jk_botti_mm_sse3" VARIANT_EXT, true, true);
 
-   ASSERT_INT(shim_test_load_variant("/mock/", "jk_botti_mm_sse3.dll"), 1);
+   ASSERT_INT(shim_test_load_variant("/mock/", "jk_botti_mm_sse3" VARIANT_EXT), 1);
    ASSERT_INT((int)load_attempts.size(), 1);
    PASS();
    return 0;
@@ -260,9 +258,9 @@ static int test_load_variant_direct_missing_sym(void)
 {
    TEST("load_variant fails when a symbol is missing");
    reset_all();
-   add_lib("jk_botti_mm_sse3.dll", true, false);
+   add_lib("jk_botti_mm_sse3" VARIANT_EXT, true, false);
 
-   ASSERT_INT(shim_test_load_variant("/mock/", "jk_botti_mm_sse3.dll"), 0);
+   ASSERT_INT(shim_test_load_variant("/mock/", "jk_botti_mm_sse3" VARIANT_EXT), 0);
    PASS();
    return 0;
 }
@@ -271,13 +269,13 @@ static int test_load_variant_closes_handle_on_sym_failure(void)
 {
    TEST("load_variant closes module handle when symbol resolution fails");
    reset_all();
-   add_lib("jk_botti_mm_sse3.dll", true, false);
+   add_lib("jk_botti_mm_sse3" VARIANT_EXT, true, false);
 
-   ASSERT_INT(shim_test_load_variant("/mock/", "jk_botti_mm_sse3.dll"), 0);
-   ASSERT_INT((int)free_attempts.size(), 1);
-   MockLib *loaded = &mock_libs["/mock/jk_botti_mm_sse3.dll"];
-   if (free_attempts[0] != loaded) {
-      printf("  FreeLibrary called on wrong handle\n");
+   ASSERT_INT(shim_test_load_variant("/mock/", "jk_botti_mm_sse3" VARIANT_EXT), 0);
+   ASSERT_INT((int)close_attempts.size(), 1);
+   MockLib *loaded = &mock_libs["/mock/jk_botti_mm_sse3" VARIANT_EXT];
+   if (close_attempts[0] != loaded) {
+      printf("  dl_close called on wrong handle\n");
       return 1;
    }
    PASS();
@@ -288,17 +286,307 @@ static int test_fallback_frees_handle_on_sym_failure(void)
 {
    TEST("fallback path frees handle from variant with missing symbols");
    reset_all();
-   add_lib("jk_botti_mm_avx2fma.dll", true,  false);  // loads, no syms
-   add_lib("jk_botti_mm_sse3.dll",    true,  true);
-   add_lib("jk_botti_mm_x87.dll",     true,  true);
+   add_lib("jk_botti_mm_avx2fma" VARIANT_EXT, true,  false);
+   add_lib("jk_botti_mm_sse3" VARIANT_EXT,    true,  true);
+   add_lib("jk_botti_mm_x87" VARIANT_EXT,     true,  true);
    mock_has_avx2_fma_val = 1;
    mock_has_sse3_val     = 1;
 
    ASSERT_INT(shim_test_ensure_loaded(), 1);
-   ASSERT_INT((int)free_attempts.size(), 1);
-   MockLib *avx = &mock_libs["/mock/jk_botti_mm_avx2fma.dll"];
-   if (free_attempts[0] != avx) {
+   ASSERT_INT((int)close_attempts.size(), 1);
+   MockLib *avx = &mock_libs["/mock/jk_botti_mm_avx2fma" VARIANT_EXT];
+   if (close_attempts[0] != avx) {
       printf("  expected avx2fma handle to be freed\n");
+      return 1;
+   }
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// Proxy tests - cvar registration
+// ============================================================
+
+static std::vector<cvar_t *> mock_registered_cvars;
+
+static void mock_real_CVarRegister(cvar_t *cv)
+{
+   mock_registered_cvars.push_back(cv);
+}
+
+static void reset_proxy_state(void)
+{
+   shim_test_reset();
+   mock_registered_cvars.clear();
+   shim_test_set_real_CVarRegister(mock_real_CVarRegister);
+}
+
+static int test_cvar_register_copies_to_local_storage(void)
+{
+   TEST("shim_CVarRegister copies cvar to shim-local storage");
+   reset_proxy_state();
+
+   cvar_t original = {};
+   original.name = "jk_botti_skill";
+   original.string = "3";
+   original.value = 3.0f;
+
+   shim_test_call_CVarRegister(&original);
+
+   ASSERT_INT(shim_test_get_proxy_cvar_count(), 1);
+   cvar_t *local = shim_test_get_proxy_cvar(0);
+   ASSERT_STR(local->name, "jk_botti_skill");
+   ASSERT_INT((int)local->value, 3);
+   // Must have been registered with the LOCAL copy, not the original
+   ASSERT_INT((int)mock_registered_cvars.size(), 1);
+   if (mock_registered_cvars[0] != local) {
+      printf("  real CVarRegister called with original ptr, not local copy\n");
+      return 1;
+   }
+   if (mock_registered_cvars[0] == &original) {
+      printf("  real CVarRegister should not get the original pointer\n");
+      return 1;
+   }
+   PASS();
+   return 0;
+}
+
+static int test_cvar_register_multiple(void)
+{
+   TEST("shim_CVarRegister handles multiple cvars");
+   reset_proxy_state();
+
+   cvar_t cv1 = {}; cv1.name = "cvar_one";
+   cvar_t cv2 = {}; cv2.name = "cvar_two";
+   cvar_t cv3 = {}; cv3.name = "cvar_three";
+
+   shim_test_call_CVarRegister(&cv1);
+   shim_test_call_CVarRegister(&cv2);
+   shim_test_call_CVarRegister(&cv3);
+
+   ASSERT_INT(shim_test_get_proxy_cvar_count(), 3);
+   ASSERT_STR(shim_test_get_proxy_cvar(0)->name, "cvar_one");
+   ASSERT_STR(shim_test_get_proxy_cvar(1)->name, "cvar_two");
+   ASSERT_STR(shim_test_get_proxy_cvar(2)->name, "cvar_three");
+   ASSERT_INT((int)mock_registered_cvars.size(), 3);
+   PASS();
+   return 0;
+}
+
+static int test_cvar_register_overflow_passes_original(void)
+{
+   TEST("shim_CVarRegister passes original ptr when proxy slots full");
+   reset_proxy_state();
+
+   cvar_t cvars[MAX_PROXY_CVARS + 1];
+   for (int i = 0; i <= MAX_PROXY_CVARS; i++) {
+      memset(&cvars[i], 0, sizeof(cvar_t));
+      cvars[i].name = "overflow_test";
+      shim_test_call_CVarRegister(&cvars[i]);
+   }
+
+   ASSERT_INT(shim_test_get_proxy_cvar_count(), MAX_PROXY_CVARS);
+   ASSERT_INT((int)mock_registered_cvars.size(), MAX_PROXY_CVARS + 1);
+   // Last one should be the original pointer (overflow case)
+   if (mock_registered_cvars[MAX_PROXY_CVARS] != &cvars[MAX_PROXY_CVARS]) {
+      printf("  overflow cvar should pass original pointer\n");
+      return 1;
+   }
+   PASS();
+   return 0;
+}
+
+static int test_cvar_register_noop_without_real(void)
+{
+   TEST("shim_CVarRegister is no-op when g_real_CVarRegister is NULL");
+   shim_test_reset();
+   // Don't set g_real_CVarRegister
+
+   cvar_t cv = {};
+   cv.name = "test";
+   shim_test_call_CVarRegister(&cv);
+
+   ASSERT_INT(shim_test_get_proxy_cvar_count(), 0);
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// Proxy tests - command registration
+// ============================================================
+
+struct CmdRecord {
+   std::string name;
+   void (*handler)(void);
+};
+static std::vector<CmdRecord> mock_registered_cmds;
+
+static void mock_real_AddServerCommand(char *name, void (*fn)(void))
+{
+   mock_registered_cmds.push_back({name, fn});
+}
+
+static int cmd_call_count;
+static void test_cmd_handler_a(void) { cmd_call_count += 1; }
+static void test_cmd_handler_b(void) { cmd_call_count += 10; }
+
+static void reset_cmd_state(void)
+{
+   shim_test_reset();
+   mock_registered_cmds.clear();
+   cmd_call_count = 0;
+   shim_test_set_real_AddServerCommand(mock_real_AddServerCommand);
+}
+
+static int test_cmd_register_uses_trampoline(void)
+{
+   TEST("shim_AddServerCommand registers trampoline, not original");
+   reset_cmd_state();
+
+   shim_test_call_AddServerCommand((char *)"jk_botti", test_cmd_handler_a);
+
+   ASSERT_INT(shim_test_get_proxy_cmd_count(), 1);
+   ASSERT_INT((int)mock_registered_cmds.size(), 1);
+   ASSERT_STR(mock_registered_cmds[0].name.c_str(), "jk_botti");
+   // Handler should be the trampoline, not the original
+   if (mock_registered_cmds[0].handler == test_cmd_handler_a) {
+      printf("  registered handler is original, not trampoline\n");
+      return 1;
+   }
+   // Trampoline should be the proxy handler for slot 0
+   if (mock_registered_cmds[0].handler != shim_test_get_proxy_cmd_handler(0)) {
+      printf("  registered handler is not proxy_cmd_handler_0\n");
+      return 1;
+   }
+   PASS();
+   return 0;
+}
+
+static int test_cmd_trampoline_calls_target(void)
+{
+   TEST("command trampoline calls the real handler function");
+   reset_cmd_state();
+
+   shim_test_call_AddServerCommand((char *)"cmd1", test_cmd_handler_a);
+   shim_test_call_AddServerCommand((char *)"cmd2", test_cmd_handler_b);
+
+   // Call through the trampolines
+   mock_registered_cmds[0].handler();
+   ASSERT_INT(cmd_call_count, 1);
+
+   mock_registered_cmds[1].handler();
+   ASSERT_INT(cmd_call_count, 11);
+   PASS();
+   return 0;
+}
+
+static int test_cmd_register_overflow_passes_original(void)
+{
+   TEST("shim_AddServerCommand passes original fn when proxy slots full");
+   reset_cmd_state();
+
+   void (*handlers[])(void) = {
+      test_cmd_handler_a, test_cmd_handler_a,
+      test_cmd_handler_a, test_cmd_handler_a,
+      test_cmd_handler_b,  // 5th = overflow
+   };
+
+   for (int i = 0; i < 5; i++)
+      shim_test_call_AddServerCommand((char *)"cmd", handlers[i]);
+
+   ASSERT_INT(shim_test_get_proxy_cmd_count(), MAX_PROXY_CMDS);
+   ASSERT_INT((int)mock_registered_cmds.size(), 5);
+   // 5th (overflow) should be the original function pointer
+   if (mock_registered_cmds[4].handler != test_cmd_handler_b) {
+      printf("  overflow cmd should pass original handler\n");
+      return 1;
+   }
+   PASS();
+   return 0;
+}
+
+static int test_cmd_register_noop_without_real(void)
+{
+   TEST("shim_AddServerCommand is no-op when g_real_AddServerCommand is NULL");
+   shim_test_reset();
+   mock_registered_cmds.clear();
+
+   shim_test_call_AddServerCommand((char *)"test", test_cmd_handler_a);
+
+   ASSERT_INT(shim_test_get_proxy_cmd_count(), 0);
+   ASSERT_INT((int)mock_registered_cmds.size(), 0);
+   PASS();
+   return 0;
+}
+
+// ============================================================
+// GiveFnptrsToDll patching test
+// ============================================================
+
+static enginefuncs_t *captured_engfuncs;
+static globalvars_t *captured_globals;
+
+static void WINAPI mock_variant_GiveFnptrsToDll(enginefuncs_t *eng, globalvars_t *glob)
+{
+   captured_engfuncs = eng;
+   captured_globals = glob;
+}
+
+static void mock_engine_CVarRegister(cvar_t *cv) { (void)cv; }
+static void mock_engine_AddServerCommand(char *name, void (*fn)(void)) { (void)name; (void)fn; }
+
+static int test_give_fnptrs_patches_engfuncs(void)
+{
+   TEST("GiveFnptrsToDll patches cvar/cmd functions in engine table");
+   reset_all();
+   add_lib("jk_botti_mm_sse3" VARIANT_EXT, true, true);
+   mock_has_sse3_val = 1;
+   captured_engfuncs = NULL;
+   captured_globals = NULL;
+
+   // Force load so ensure_loaded() succeeds
+   shim_test_ensure_loaded();
+
+   // Set up the variant's GiveFnptrsToDll to our mock
+   p_GiveFnptrsToDll = (GIVE_ENGINE_FUNCTIONS_FN)mock_variant_GiveFnptrsToDll;
+
+   // Set up a fake engine function table
+   enginefuncs_t fake_eng;
+   memset(&fake_eng, 0, sizeof(fake_eng));
+   fake_eng.pfnCVarRegister = mock_engine_CVarRegister;
+   fake_eng.pfnCvar_RegisterVariable = mock_engine_CVarRegister;
+   fake_eng.pfnAddServerCommand = mock_engine_AddServerCommand;
+
+   globalvars_t fake_globals;
+   memset(&fake_globals, 0, sizeof(fake_globals));
+
+   GiveFnptrsToDll(&fake_eng, &fake_globals);
+
+   // Variant should have received the patched copy, not the original
+   if (captured_engfuncs == NULL) {
+      printf("  variant GiveFnptrsToDll was not called\n");
+      return 1;
+   }
+   if (captured_engfuncs == &fake_eng) {
+      printf("  variant got original engfuncs, not the patched copy\n");
+      return 1;
+   }
+   // The patched table should have our interceptors
+   if ((void *)captured_engfuncs->pfnCVarRegister == (void *)mock_engine_CVarRegister) {
+      printf("  pfnCVarRegister was not replaced with shim interceptor\n");
+      return 1;
+   }
+   if ((void *)captured_engfuncs->pfnCvar_RegisterVariable == (void *)mock_engine_CVarRegister) {
+      printf("  pfnCvar_RegisterVariable was not replaced\n");
+      return 1;
+   }
+   if ((void *)captured_engfuncs->pfnAddServerCommand == (void *)mock_engine_AddServerCommand) {
+      printf("  pfnAddServerCommand was not replaced with shim interceptor\n");
+      return 1;
+   }
+   // Globals should pass through
+   if (captured_globals != &fake_globals) {
+      printf("  globals pointer was not passed through\n");
       return 1;
    }
    PASS();
@@ -326,6 +614,15 @@ int main(void)
    fail |= test_load_variant_direct_missing_sym();
    fail |= test_load_variant_closes_handle_on_sym_failure();
    fail |= test_fallback_frees_handle_on_sym_failure();
+   fail |= test_cvar_register_copies_to_local_storage();
+   fail |= test_cvar_register_multiple();
+   fail |= test_cvar_register_overflow_passes_original();
+   fail |= test_cvar_register_noop_without_real();
+   fail |= test_cmd_register_uses_trampoline();
+   fail |= test_cmd_trampoline_calls_target();
+   fail |= test_cmd_register_overflow_passes_original();
+   fail |= test_cmd_register_noop_without_real();
+   fail |= test_give_fnptrs_patches_engfuncs();
 
    printf("\n%d/%d tests passed\n", tests_passed, tests_run);
    return fail ? EXIT_FAILURE : EXIT_SUCCESS;


### PR DESCRIPTION
## Summary
- Intercept `pfnCVarRegister` and `pfnAddServerCommand` in the engine function table passed to the variant, copying cvar structs and command handler trampolines into shim-local storage so `dladdr()` resolves to the shim's address space
- Convert shim from C to C++ (`shim.c` -> `shim.cpp`) using proper SDK headers (`extdll.h`, `meta_api.h`) and Metamod type definitions instead of hand-rolled `void*` typedefs
- Add `FORCE_STACK_ALIGN` to all exported entry points called by engine/metamod
- Remove now-unnecessary `static_assert` offset checks from `h_export.cpp`

## Background
Metamod identifies which plugin owns a cvar/command by calling `dladdr()` on the `cvar_t*` or command-handler function pointer. With the shim architecture, these addresses resolve to the variant `.so` (loaded via `dlopen` with `RTLD_LOCAL`) rather than the shim `.so` that metamod actually loaded, causing `meta cvars` to show "(unknown)".

## Test plan
- [x] All existing tests pass (32-bit cross-compiler)
- [x] Linux shim and variant builds clean
- [x] Win32 cross-compile builds clean
- [x] Shim test updated and passes (12/12)