### PR TITLE
Add endbr32 prefix to sendto hook trampoline

### DIFF
--- a/bot_query_hook_linux.cpp
+++ b/bot_query_hook_linux.cpp
@@ -29,14 +29,10 @@
 // Linux work, based on my "Linux code for dynamic linkents" from metamod-p
 //
 
-// 0xe9 is opcode for our function forwarder
-#define JMP_SIZE 1
-
-//pointer size on x86-32: 4 bytes
-#define PTR_SIZE sizeof(void*)
-
-//opcode + sizeof pointer
-#define BYTES_SIZE (JMP_SIZE + PTR_SIZE)
+// endbr32 (4 bytes) + jmp rel32 (5 bytes)
+#define ENDBR32_SIZE 4
+#define JMP_INSN_SIZE 5
+#define BYTES_SIZE (ENDBR32_SIZE + JMP_INSN_SIZE)
 
 typedef ssize_t (*sendto_func)(int socket, const void *message, size_t length, int flags, const struct sockaddr *dest_addr, socklen_t dest_len);
 
@@ -54,12 +50,16 @@ static unsigned char sendto_old_bytes[BYTES_SIZE];
 //Mutex for our protection
 static pthread_mutex_t mutex_replacement_sendto = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 
-//constructs new jmp forwarder
+//constructs endbr32 + jmp forwarder
 static void construct_jmp_instruction(void *x, void *place, void *target)
 {
-   unsigned long offset = ((unsigned long)target) - (((unsigned long)place) + 5);
-   ((unsigned char *)x)[0] = 0xe9;
-   memcpy((char *)x + 1, &offset, sizeof(unsigned long));
+   unsigned char *p = (unsigned char *)x;
+   // endbr32: f3 0f 1e fb
+   p[0] = 0xf3; p[1] = 0x0f; p[2] = 0x1e; p[3] = 0xfb;
+   // jmp rel32 (offset relative to end of jmp instruction)
+   p[4] = 0xe9;
+   unsigned long offset = ((unsigned long)target) - (((unsigned long)place) + BYTES_SIZE);
+   memcpy(p + 5, &offset, sizeof(unsigned long));
 }
 
 //restores old sendto

--- a/tests/test_bot_query_hook_linux.cpp
+++ b/tests/test_bot_query_hook_linux.cpp
@@ -43,25 +43,28 @@ ssize_t sendto_hook(int socket, const void *message, size_t length, int flags,
 
 static int test_construct_jmp_basic(void)
 {
-   TEST("construct_jmp_instruction: opcode is 0xE9");
+   TEST("construct_jmp_instruction: endbr32 + jmp forward");
 
-   unsigned char buf[8];
+   unsigned char buf[BYTES_SIZE];
    memset(buf, 0, sizeof(buf));
 
-   // Place a dummy place and target at known addresses
-   // place = 0x1000, target = 0x2000
-   // relative offset = target - (place + 5) = 0x2000 - 0x1005 = 0x0FFB
    void *place = (void *)0x1000;
    void *target = (void *)0x2000;
 
    construct_jmp_instruction(buf, place, target);
 
-   ASSERT_INT(buf[0], 0xE9);
+   // endbr32: f3 0f 1e fb
+   ASSERT_INT(buf[0], 0xf3);
+   ASSERT_INT(buf[1], 0x0f);
+   ASSERT_INT(buf[2], 0x1e);
+   ASSERT_INT(buf[3], 0xfb);
+   // jmp opcode
+   ASSERT_INT(buf[4], 0xE9);
 
-   // Check relative offset
+   // Check relative offset (relative to end of the jmp instruction = place + 9)
    unsigned long offset;
-   memcpy(&offset, buf + 1, sizeof(offset));
-   unsigned long expected = (unsigned long)target - ((unsigned long)place + 5);
+   memcpy(&offset, buf + 5, sizeof(offset));
+   unsigned long expected = (unsigned long)target - ((unsigned long)place + BYTES_SIZE);
    ASSERT_TRUE(offset == expected);
 
    PASS();
@@ -72,7 +75,7 @@ static int test_construct_jmp_backward(void)
 {
    TEST("construct_jmp_instruction: backward jump offset");
 
-   unsigned char buf[8];
+   unsigned char buf[BYTES_SIZE];
    memset(buf, 0, sizeof(buf));
 
    void *place = (void *)0x2000;
@@ -80,11 +83,15 @@ static int test_construct_jmp_backward(void)
 
    construct_jmp_instruction(buf, place, target);
 
-   ASSERT_INT(buf[0], 0xE9);
+   // endbr32
+   ASSERT_INT(buf[0], 0xf3);
+   ASSERT_INT(buf[3], 0xfb);
+   // jmp opcode
+   ASSERT_INT(buf[4], 0xE9);
 
    unsigned long offset;
-   memcpy(&offset, buf + 1, sizeof(offset));
-   unsigned long expected = (unsigned long)target - ((unsigned long)place + 5);
+   memcpy(&offset, buf + 5, sizeof(offset));
+   unsigned long expected = (unsigned long)target - ((unsigned long)place + BYTES_SIZE);
    ASSERT_TRUE(offset == expected);
 
    PASS();
@@ -123,8 +130,9 @@ static int test_hook_sendto(void)
    // sendto_original should be non-null (resolved &sendto)
    ASSERT_TRUE(sendto_original != NULL);
 
-   // The first byte of sendto should now be 0xE9 (JMP)
-   ASSERT_INT(((unsigned char *)sendto_original)[0], 0xE9);
+   // The first 4 bytes of sendto should now be endbr32, then 0xE9 (JMP)
+   ASSERT_INT(((unsigned char *)sendto_original)[0], 0xf3);
+   ASSERT_INT(((unsigned char *)sendto_original)[4], 0xE9);
 
    // The old bytes should have been saved
    // We can verify by unhooking and checking restoration


### PR DESCRIPTION
## Summary
- Prepend `endbr32` (f3 0f 1e fb) to the `jmp rel32` trampoline written over `sendto`, expanding from 5 to 9 bytes
- Required for CET/IBT (Control-flow Enforcement Technology) on modern x86 kernels where indirect call targets must begin with `endbr32`

## Test plan
- [x] `test_bot_query_hook_linux` updated and passes (6/6)
- [x] Full test suite passes
- [x] Linux and Win32 builds clean