### PR TITLE
Fix win32 shim linking against libgcc_s_dw2-1.dll

### DIFF
--- a/.github/scripts/verify_dll.py
+++ b/.github/scripts/verify_dll.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import pefile, sys
+
+REQUIRED_EXPORTS = {
+    b'GetEngineFunctions', b'GetEngineFunctions_POST',
+    b'GetEntityAPI2', b'GetEntityAPI2_POST',
+    b'GiveFnptrsToDll', b'GiveFnptrsToDll@8',
+    b'Meta_Attach', b'Meta_Detach', b'Meta_Query',
+}
+ALLOWED_IMPORTS = {'kernel32.dll', 'msvcrt.dll', 'wsock32.dll', 'ws2_32.dll'}
+
+dlls = ['jk_botti_mm.dll', 'jk_botti_mm_x87.dll',
+        'jk_botti_mm_sse3.dll', 'jk_botti_mm_avx2fma.dll']
+fail = False
+for dll in dlls:
+    print(f'=== {dll} ===')
+    pe = pefile.PE(dll)
+
+    exports = set()
+    if hasattr(pe, 'DIRECTORY_ENTRY_EXPORT'):
+        for exp in pe.DIRECTORY_ENTRY_EXPORT.symbols:
+            if exp.name:
+                exports.add(exp.name)
+    print(f'  Exports: {sorted(e.decode() for e in exports)}')
+    for sym in sorted(REQUIRED_EXPORTS):
+        if sym not in exports:
+            print(f'  FAIL: missing export {sym.decode()}')
+            fail = True
+
+    imports = set()
+    if hasattr(pe, 'DIRECTORY_ENTRY_IMPORT'):
+        for entry in pe.DIRECTORY_ENTRY_IMPORT:
+            imports.add(entry.dll.decode().lower())
+    print(f'  Imports: {sorted(imports)}')
+    for dep in imports:
+        if dep not in ALLOWED_IMPORTS:
+            print(f'  FAIL: unexpected import {dep}')
+            fail = True
+
+    pe.close()
+
+sys.exit(1 if fail else 0)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,10 @@ jobs:
             VERFLAGS="VER_MAJOR=${{ inputs.ver_major }} VER_MINOR=${{ inputs.ver_minor }} VER_NOTE=${{ inputs.ver_note }}"
           fi
           make -j4 OSTYPE=win32 variants $VERFLAGS
+      - name: Verify DLL exports and imports
+        run: |
+          pip install pefile
+          python3 .github/scripts/verify_dll.py
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -194,8 +194,11 @@ ifeq ($(VARIANT),shim)
 
 _build: $(OUTPUT)
 
-$(OUTPUT): shim.cpp | $(OBJDIR)
-	$(CXX) $(CXXFLAGS) -o $@ $< $(LINKFLAGS)
+$(OBJDIR)/shim.o: shim.cpp | $(OBJDIR)
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+$(OUTPUT): $(OBJDIR)/shim.o
+	$(CC) -o $@ $< $(LINKFLAGS)
 	mkdir -p addons/jk_botti/dlls
 	cp $@ addons/jk_botti/dlls/
 ifneq ($(OSTYPE),win32)

--- a/addons/jk_botti/jk_botti_readme.txt
+++ b/addons/jk_botti/jk_botti_readme.txt
@@ -1,4 +1,4 @@
-jk_botti 1.61
+jk_botti 1.62
 -------------
 
 1. Intro
@@ -10,7 +10,7 @@ jk_botti 1.61
 1. Intro
 --------------------
 
-This is 1.61 release of jk_botti, by Jussi Kivilinna <jussi.kivilinna@iki.fi>
+This is 1.62 release of jk_botti, by Jussi Kivilinna <jussi.kivilinna@iki.fi>
 You are free to use code for any of your needs.
 
 jk_botti is computer gamer for multiplayer mode of Half-Life (HLDM) and has 
@@ -66,7 +66,7 @@ Credits:
 --------------------
 2. What's new
 --------------------
-1.61:
+1.62:
  Bug fixes:
  * Fix sendto hook trampoline crash on CPUs with CET/IBT by adding endbr32
    prefix to indirect branch target (#116)


### PR DESCRIPTION
## Summary
- Fix win32 shim DLL failing to load due to `libgcc_s_dw2-1.dll` dependency
  - Split shim build into separate compile (CXX) and link (CC) steps, matching the normal variant build
- Add CI check that verifies all win32 DLLs export required Metamod entry points and only link against allowed system DLLs
  - Uses `pefile` Python library for portable PE parsing
- Update readme changelog: v1.61 skipped, release as v1.62 hotfix

## Test plan
- [x] Win32 cross-compile: `jk_botti_mm.dll` no longer imports `libgcc_s_dw2-1.dll`
- [x] Linux cross-compile: shim builds and links correctly
- [x] DLL exports unchanged (all 9 Metamod entry points present)
- [x] Verified loading on win32 game server
- [ ] CI passes with new DLL verification step